### PR TITLE
Send a deletion event (NIP-09) when deleting a story

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -32,9 +32,9 @@ class StoriesController < ApplicationController
 
   # @route DELETE /stories/:id (story)
   def destroy
-    @story.destroy
+    NostrJobs::StoryDeletionJob.perform_later(@story)
 
-    redirect_to root_path, notice: "L'aventure a bien été supprimée"
+    redirect_to root_path, notice: "L'aventure est en cours de suppression"
   end
 
   private

--- a/app/jobs/nostr_jobs/story_deletion_job.rb
+++ b/app/jobs/nostr_jobs/story_deletion_job.rb
@@ -1,0 +1,9 @@
+module NostrJobs
+  class StoryDeletionJob < ApplicationJob
+    def perform(story)
+      NostrServices::StoryDeletionEvent.call(story)
+
+      story.destroy!
+    end
+  end
+end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -91,6 +91,14 @@ class Story < ApplicationRecord
   def assign_nostr_user
     self.nostr_user = NostrUser.find_sole_by(language: language)
   end
+
+  def front_cover_pubished?
+    nostr_identifier.present?
+  end
+
+  def back_cover_published?
+    back_cover_nostr_identifier.present?
+  end
 end
 
 # == Schema Information
@@ -114,13 +122,15 @@ end
 #  nostr_identifier            :string
 #  nostr_user_id               :bigint(8)
 #  summary                     :string
+#  back_cover_nostr_identifier :string
 #
 # Indexes
 #
-#  index_stories_on_nostr_identifier      (nostr_identifier) UNIQUE
-#  index_stories_on_nostr_user_id         (nostr_user_id)
-#  index_stories_on_replicate_identifier  (replicate_identifier) UNIQUE
-#  index_stories_on_thematic_id           (thematic_id)
+#  index_stories_on_back_cover_nostr_identifier  (back_cover_nostr_identifier) UNIQUE
+#  index_stories_on_nostr_identifier             (nostr_identifier) UNIQUE
+#  index_stories_on_nostr_user_id                (nostr_user_id)
+#  index_stories_on_replicate_identifier         (replicate_identifier) UNIQUE
+#  index_stories_on_thematic_id                  (thematic_id)
 #
 # Foreign Keys
 #

--- a/app/services/nostr_back_cover_publisher_service.rb
+++ b/app/services/nostr_back_cover_publisher_service.rb
@@ -9,6 +9,8 @@ class NostrBackCoverPublisherService < ApplicationService
     event = NostrServices::ManualTextNoteEvent.call(body, nostr_user, reference)
 
     debug_logger('Nostr Back cover', event.inspect, :green)
+
+    event.last['id']
   end
 
   private

--- a/app/services/nostr_publisher_service.rb
+++ b/app/services/nostr_publisher_service.rb
@@ -25,11 +25,15 @@ class NostrPublisherService < ApplicationService
 
     sleep 1
 
-    return unless adventure_ended?
+    if adventure_ended?
+      story.ended!
 
-    story.ended!
+      reference = NostrBackCoverPublisherService.call(chapter)
+      story.back_cover_nostr_identifier = reference
+      story.save!
+    end
 
-    NostrBackCoverPublisherService.call(chapter)
+    true
   end
 
   private

--- a/app/services/nostr_services/story_deletion_event.rb
+++ b/app/services/nostr_services/story_deletion_event.rb
@@ -1,0 +1,49 @@
+module NostrServices
+  # @see https://github.com/nostr-protocol/nips/blob/master/09.md
+  class StoryDeletionEvent < NostrEvent
+    EVENT_KIND = 5 # NIP-9
+
+    attr_reader :story
+
+    def initialize(story)
+      @story = story
+    end
+
+    def call
+      nostr.build_event(payload).tap do |event|
+        nostr.test_post_event(event, relay_url)
+      end
+    end
+
+    private
+
+    def payload
+      @payload ||= {
+        kind: EVENT_KIND,
+        pubkey: public_key,
+        created_at: created_at,
+        tags: tags,
+        content: body
+      }
+    end
+
+    def tags
+      [].tap do |data|
+        data.push ['e', story.nostr_identifier] if story.front_cover_pubished?
+        data.push ['e', story.back_cover_nostr_identifier] if story.back_cover_published?
+
+        story.chapters.published.each do |chapter|
+          data.push ['e', chapter.nostr_identifier]
+        end
+      end
+    end
+
+    def body
+      ''
+    end
+
+    def nostr_user
+      story.nostr_user
+    end
+  end
+end

--- a/db/migrate/20230807155236_add_back_cover_nostr_identifier_to_story.rb
+++ b/db/migrate/20230807155236_add_back_cover_nostr_identifier_to_story.rb
@@ -1,0 +1,6 @@
+class AddBackCoverNostrIdentifierToStory < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stories, :back_cover_nostr_identifier, :string
+    add_index :stories, :back_cover_nostr_identifier, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_05_075806) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_155236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_05_075806) do
     t.string "nostr_identifier"
     t.bigint "nostr_user_id"
     t.string "summary"
+    t.string "back_cover_nostr_identifier"
+    t.index ["back_cover_nostr_identifier"], name: "index_stories_on_back_cover_nostr_identifier", unique: true
     t.index ["nostr_identifier"], name: "index_stories_on_nostr_identifier", unique: true
     t.index ["nostr_user_id"], name: "index_stories_on_nostr_user_id"
     t.index ["replicate_identifier"], name: "index_stories_on_replicate_identifier", unique: true


### PR DESCRIPTION
Broadcast a request to delete chapter's stories (including front and back chapters) when the story is destroyed from the interface.

For that, using the [NIP-09 Event Deletion](https://github.com/nostr-protocol/nips/blob/master/09.md)