### PR TITLE
Use correct locale for chapter static texts

### DIFF
--- a/app/services/nostr_back_cover_publisher_service.rb
+++ b/app/services/nostr_back_cover_publisher_service.rb
@@ -19,10 +19,7 @@ class NostrBackCoverPublisherService < ApplicationService
     <<~BACKCOVER
       🔥 📖 🤖
 
-      Si cette histoire vous a plu, n'hésitez pas à:
-
-      - suivre ce compte sur Nostr pour ne rater aucune nouvelle aventure
-      - aller faire un tour sur flownaely.cafe ☕
+      #{I18n.t('chapters.back_cover.content')}
 
       https://flownaely.cafe
     BACKCOVER

--- a/app/services/nostr_publisher_service.rb
+++ b/app/services/nostr_publisher_service.rb
@@ -6,31 +6,33 @@ class NostrPublisherService < ApplicationService
   end
 
   def call
-    if chapter.first_to_publish?
-      reference = NostrFrontCoverPublisherService.call(story)
-      story.nostr_identifier = reference
-      story.save!
-    else
-      reference = chapter.last_published.nostr_identifier
-    end
+    I18n.with_locale(story.language.first(2)) do
+      if chapter.first_to_publish?
+        reference = NostrFrontCoverPublisherService.call(story)
+        story.nostr_identifier = reference
+        story.save!
+      else
+        reference = chapter.last_published.nostr_identifier
+      end
 
-    nostr_event_identifier = NostrChapterPublisherService.call(
-      chapter, reference
-    )
+      nostr_event_identifier = NostrChapterPublisherService.call(
+        chapter, reference
+      )
 
-    chapter.update!(
-      nostr_identifier: nostr_event_identifier,
-      published_at: Time.current
-    )
+      chapter.update!(
+        nostr_identifier: nostr_event_identifier,
+        published_at: Time.current
+      )
 
-    sleep 1
+      sleep 1
 
-    if adventure_ended?
-      story.ended!
+      if adventure_ended?
+        story.ended!
 
-      reference = NostrBackCoverPublisherService.call(chapter)
-      story.back_cover_nostr_identifier = reference
-      story.save!
+        reference = NostrBackCoverPublisherService.call(chapter)
+        story.back_cover_nostr_identifier = reference
+        story.save!
+      end
     end
 
     true

--- a/config/locales/chapters.en.yml
+++ b/config/locales/chapters.en.yml
@@ -1,0 +1,8 @@
+en:
+  chapters:
+    back_cover:
+      content: |-
+        If you enjoyed this story, please:
+
+        - follow this account on Nostr so you don't miss any new adventures
+        - check out flownaely.cafe ☕

--- a/config/locales/chapters.fr.yml
+++ b/config/locales/chapters.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  chapters:
+    back_cover:
+      content: |-
+        Si cette histoire vous a plu, n'hésitez pas à:
+
+        - suivre ce compte sur Nostr pour ne rater aucune nouvelle aventure
+        - aller faire un tour sur flownaely.cafe ☕


### PR DESCRIPTION
Execute the publication to Nostr using the story language context.
This ensure that back cover content (and any static texts) are proprely translated when published.