### PR TITLE
📦 UPDATE gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,100 +2,53 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.2.0'
-
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.6'
-
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem 'sprockets-rails'
-
-# Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', '~> 5.0'
-
-# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-gem 'importmap-rails'
-
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem 'turbo-rails'
-
-# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-gem 'stimulus-rails'
-
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem 'jbuilder'
-
-# Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 4.0'
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', require: false
-
-# Use Sass to process CSS
-# gem "sassc-rails"
-
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem 'image_processing', '~> 1.2'
-
-group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'debug', platforms: %i[mri mingw x64_mingw]
-end
-
-group :development do
-  # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'web-console'
-
-  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
-
-  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
-end
-
-group :test do
-  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem 'capybara'
-  gem 'selenium-webdriver'
-  gem 'webdrivers'
-end
 
 gem 'action_policy'
 gem 'acts_as_list'
+gem 'bootsnap', require: false
 gem 'dotenv-rails'
 gem 'faker'
 gem 'human_attributes'
+gem 'importmap-rails'
+gem 'jbuilder'
 gem 'lograge'
 gem 'nostr_ruby'
 gem 'openai_chatgpt'
 gem 'pagy'
 gem 'pg'
+gem 'puma', '~> 5.0'
 gem 'rails-i18n'
+gem 'redis', '~> 4.0'
 gem 'replicate-ruby'
 gem 'sidekiq'
 gem 'simple_form'
 gem 'slim-rails'
 gem 'sorcery'
+gem 'sprockets-rails'
+gem 'stimulus-rails'
 gem 'tailwindcss-rails'
+gem 'turbo-rails'
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'whenever', require: false
+
+group :development, :test do
+  gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'rubocop'
+  gem 'rubocop-performance'
+  gem 'rubocop-rails'
+end
 
 group :development do
   gem 'annotate'
   gem 'bullet'
   gem 'chusaku', require: false
   gem 'letter_opener'
+  gem 'web-console'
 end
 
-group :development, :test do
-  gem 'rubocop'
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
+group :test do
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       tzinfo (~> 2.0)
     acts_as_list (1.1.0)
       activerecord (>= 4.2)
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
@@ -99,7 +99,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chronic (0.10.2)
-    chusaku (1.0.0)
+    chusaku (1.0.1)
       railties (>= 3.0)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -233,7 +233,7 @@ GEM
       activesupport (= 7.0.6)
       bundler (>= 1.15.0)
       railties (= 7.0.6)
-    rails-dom-testing (2.1.1)
+    rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -253,7 +253,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     redis (4.8.1)
-    redis-client (0.14.1)
+    redis-client (0.15.0)
       connection_pool
     regexp_parser (2.8.1)
     reline (0.3.7)
@@ -323,7 +323,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stimulus-rails (1.2.1)
+    stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.30-x86_64-darwin)
       railties (>= 6.0.0)
@@ -348,10 +348,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     websocket (1.2.9)
     websocket-client-simple (0.6.1)
       event_emitter
@@ -363,7 +363,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.10)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   x86_64-darwin-22


### PR DESCRIPTION
* addressable 2.8.4 → 2.8.5
[changelog](https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md#addressable-285)

* chusaku 1.0.0 → 1.0.1

* rails-dom-testing 2.1.1 → 2.2.0

* redis-client 0.14.1 → 0.15.0
[changelog](https://github.com/redis-rb/redis-client/blob/master/CHANGELOG.md#0150)

* stimulus-rails 1.2.1 → 1.2.2

* webdrivers 5.2.0 → 5.3.1
[changelog](https://github.com/titusfortner/webdrivers/blob/v5.3.1/CHANGELOG.md#531-2023-07-31)

* zeitwerk 2.6.10 → 2.6.11
[changelog](https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md#2611-2-august-2023)