### PR TITLE
Enable `NostrUser`, consolidate rake tasks and protect webhooks publications

### DIFF
--- a/app/controllers/nostr_users_controller.rb
+++ b/app/controllers/nostr_users_controller.rb
@@ -17,7 +17,7 @@ class NostrUsersController < ApplicationController
 
     respond_to do |format|
       if @nostr_user.save
-        format.html { redirect_to nostr_users_path(@nostr_user), notice: 'Nostr user was successfully created.' }
+        format.html { redirect_to nostr_users_path, notice: 'Nostr user was successfully created.' }
         format.json { render :show, status: :created, location: @nostr_user }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -35,7 +35,7 @@ class NostrUsersController < ApplicationController
   def update
     respond_to do |format|
       if @nostr_user.update(nostr_user_params)
-        format.html { redirect_to nostr_users_path(@nostr_user), notice: 'Nostr user was successfully updated.' }
+        format.html { redirect_to nostr_users_path, notice: 'Nostr user was successfully updated.' }
         format.json { render :show, status: :ok, location: @nostr_user }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -63,6 +63,10 @@ class NostrUsersController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def nostr_user_params
-    params.require(:nostr_user).permit(:name, :public_key, :private_key, :relay_url, :language, :avatar)
+    params.require(:nostr_user)
+          .permit(
+            :name, :public_key, :private_key,
+            :relay_url, :language, :avatar, :enabled
+          )
   end
 end

--- a/app/exceptions/chapter_errors.rb
+++ b/app/exceptions/chapter_errors.rb
@@ -2,4 +2,47 @@ class ChapterErrors < BaseErrors
   EmptyPollOptions = Class.new(self)
   MissingPollOptions = Class.new(self)
   FullStoryMissingChapters = Class.new(self)
+
+  ChapterAlreadyPublished = Class.new(self) do
+    attr_reader :chapter
+
+    def initialize(chapter:)
+      super()
+
+      @chapter = chapter
+    end
+
+    def message
+      I18n.t(
+        class_name,
+        chapter_position: chapter.position,
+        chapter_title: chapter.title,
+        scope: i18n_scope
+      )
+    end
+  end
+
+  PreviousChapterNotPublished = Class.new(self) do
+    attr_reader :chapter, :previous_chapter
+
+    def initialize(chapter, previous_chapter)
+      super()
+
+      @chapter = chapter
+      @previous_chapter = previous_chapter
+    end
+
+    def message
+      I18n.t(
+        class_name,
+        story_id: chapter.story.id,
+        story_title: chapter.story.title,
+        chapter_position: chapter.position,
+        chapter_title: chapter.title,
+        previous_chapter_position: previous_chapter.position,
+        previous_chapter_title: previous_chapter.title,
+        scope: i18n_scope
+      )
+    end
+  end
 end

--- a/app/exceptions/nostr_user_errors.rb
+++ b/app/exceptions/nostr_user_errors.rb
@@ -1,0 +1,34 @@
+class NostrUserErrors < BaseErrors
+  BotMissing = Class.new(self) do
+    attr_reader :language
+
+    def initialize(language:)
+      super()
+
+      @language = language
+    end
+
+    def message
+      I18n.t(class_name, language: language, scope: i18n_scope)
+    end
+  end
+
+  BotDisabled = Class.new(self) do
+    attr_reader :nostr_user
+
+    def initialize(nostr_user:)
+      super()
+
+      @nostr_user = nostr_user
+    end
+
+    def message
+      I18n.t(
+        class_name,
+        name: nostr_user.name,
+        language: nostr_user.human_language,
+        scope: i18n_scope
+      )
+    end
+  end
+end

--- a/app/jobs/nostr_jobs/all_publisher_job.rb
+++ b/app/jobs/nostr_jobs/all_publisher_job.rb
@@ -1,14 +1,16 @@
 module NostrJobs
   class AllPublisherJob < NostrJob
+    retry_on StoryErrors::MissingCover,
+             ChapterErrors::PreviousChapterNotPublished,
+             wait: 10.seconds,
+             jitter: 0.30,
+             attempts: 25
+
     def perform(story)
       raise StoryErrors::MissingCover unless story.cover.attached?
 
       story.chapters.not_published.by_position.each do |chapter|
         NostrPublisherService.call(chapter)
-        chapter.broadcast_chapter
-        story.broadcast_next_quick_look_story if story.publishable_story?
-
-        sleep 2
       end
     end
   end

--- a/app/jobs/nostr_jobs/single_publisher_job.rb
+++ b/app/jobs/nostr_jobs/single_publisher_job.rb
@@ -1,13 +1,17 @@
 module NostrJobs
   class SinglePublisherJob < NostrJob
+    retry_on StoryErrors::MissingCover,
+             ChapterErrors::PreviousChapterNotPublished,
+             wait: 10.seconds,
+             jitter: 0.30,
+             attempts: 25
+
     def perform(chapter)
       story = chapter.story
 
       raise StoryErrors::MissingCover unless story.cover.attached?
 
       NostrPublisherService.call(chapter)
-      chapter.broadcast_chapter
-      story.broadcast_next_quick_look_story if story.publishable_story?
     end
   end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -56,6 +56,10 @@ class Chapter < ApplicationRecord
   def most_voted_option
     options.sample
   end
+
+  def previous
+    story.chapters.find_by(position: position - 1)
+  end
 end
 
 # == Schema Information

--- a/app/models/nostr_user.rb
+++ b/app/models/nostr_user.rb
@@ -5,6 +5,10 @@ class NostrUser < ApplicationRecord
 
   encrypts :public_key, :private_key
 
+  humanize :language, enum: true
+
+  scope :enabled, -> { where(enabled: true) }
+
   validates :name, presence: true
   # validates :public_key, presence: true
   validates :private_key, presence: true
@@ -28,6 +32,7 @@ end
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  stories_count :integer          default(0), not null
+#  enabled       :boolean          default(TRUE), not null
 #
 # Indexes
 #

--- a/app/views/nostr_users/_form.html.slim
+++ b/app/views/nostr_users/_form.html.slim
@@ -19,5 +19,7 @@
     - if f.object.avatar.attached?
       = image_tag polymorphic_path(f.object.avatar), class: 'w-64'
 
+    = f.input :enabled, as: :boolean
+
   .form-actions
     = f.button :submit

--- a/app/views/nostr_users/_nostr_user.html.slim
+++ b/app/views/nostr_users/_nostr_user.html.slim
@@ -1,4 +1,4 @@
-.bg-white.border.border-gray-200.rounded-lg.shadow
+.bg-white.border.border-gray-200.rounded-lg.shadow class=('opacity-50' unless nostr_user.enabled?)
   .flex.flex-col.items-center.py-10
     header.mb-2
       - if nostr_user.avatar.attached?

--- a/config/locales/chapter_errors.fr.yml
+++ b/config/locales/chapter_errors.fr.yml
@@ -4,3 +4,7 @@ fr:
       empty_poll_options: Options de réponses au sondage manquantes
       missing_poll_options: 2 réponses minimum sont requises pour les options de sondage
       full_story_missing_chapters: 3 chapitres minimum sont requis pour pré-générer l'aventure
+      chapter_already_published: Le chapitre [#%{chapter_position}] "%{chapter_title}" a déjà été publié
+      previous_chapter_not_published: |-
+        Une erreur s'est produite avec l'aventure "%{story_title}" (#%{story_id}): le chapitre
+        [#%{chapter_position}] "%{chapter_title}" n'a pu être publié car le chapitre précédent [#%{previous_chapter_position}] "%{previous_chapter_title}" ne l'est pas.

--- a/config/locales/nostr_user_errors.en.yml
+++ b/config/locales/nostr_user_errors.en.yml
@@ -1,0 +1,5 @@
+en:
+  exceptions:
+    nostr_user_errors:
+      bot_missing: "No bot exists to handle \"%{language}\" language, please configure one to publish"
+      bot_disabled: "%{name} bot is disabled for \"%{language}\", you cannot published until you enabled it"

--- a/config/locales/nostr_user_errors.fr.yml
+++ b/config/locales/nostr_user_errors.fr.yml
@@ -1,0 +1,5 @@
+fr:
+  exceptions:
+    nostr_user_errors:
+      bot_missing: "Aucun bot n'existe pour gérer la langue \"%{language}\", veuillez en configurer un pour publier"
+      bot_disabled: "%{name} bot est désactivé pour la langue \"%{language}\", vous ne pourrez pas publier avant de le réactiver"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,6 @@
+---
+:concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY") { 5 } %>
+
+:queues:
+  - default
+  - nostr

--- a/db/migrate/20230808071551_add_enabled_to_nostr_user.rb
+++ b/db/migrate/20230808071551_add_enabled_to_nostr_user.rb
@@ -1,0 +1,5 @@
+class AddEnabledToNostrUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :nostr_users, :enabled, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_07_155236) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_08_071551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_155236) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "stories_count", default: 0, null: false
+    t.boolean "enabled", default: true, null: false
     t.index ["private_key"], name: "index_nostr_users_on_private_key", unique: true
     t.index ["public_key"], name: "index_nostr_users_on_public_key", unique: true
   end


### PR DESCRIPTION
Details:
- Adds a new boolean to `enable` or `disable` a `NostrUser` bot from interface.
- Update the `stories.rake` tasks to log case when language is not known or `NostrUser` is disabled.
- Better handling of Nostr publication exception adding a check if chapter is already published or previous chapter not yet published.
- Update Sidekiq configuration to run jobs on `nostr` queue.