### PR TITLE
Remove `public_key` column on `NostrUser`

### DIFF
--- a/app/controllers/nostr_users_controller.rb
+++ b/app/controllers/nostr_users_controller.rb
@@ -65,8 +65,8 @@ class NostrUsersController < ApplicationController
   def nostr_user_params
     params.require(:nostr_user)
           .permit(
-            :name, :public_key, :private_key,
-            :relay_url, :language, :avatar, :enabled
+            :name, :private_key, :relay_url,
+            :language, :avatar, :enabled
           )
   end
 end

--- a/app/models/nostr_user.rb
+++ b/app/models/nostr_user.rb
@@ -3,14 +3,13 @@ class NostrUser < ApplicationRecord
 
   has_one_attached :avatar
 
-  encrypts :public_key, :private_key
+  encrypts :private_key
 
   humanize :language, enum: true
 
   scope :enabled, -> { where(enabled: true) }
 
   validates :name, presence: true
-  # validates :public_key, presence: true
   validates :private_key, presence: true
   validates :relay_url, presence: true
 
@@ -25,7 +24,6 @@ end
 #
 #  id            :bigint(8)        not null, primary key
 #  name          :string
-#  public_key    :string
 #  private_key   :string
 #  relay_url     :string
 #  language      :integer          not null
@@ -37,5 +35,4 @@ end
 # Indexes
 #
 #  index_nostr_users_on_private_key  (private_key) UNIQUE
-#  index_nostr_users_on_public_key   (public_key) UNIQUE
 #

--- a/app/views/nostr_users/_form.html.slim
+++ b/app/views/nostr_users/_form.html.slim
@@ -4,7 +4,6 @@
 
   .form-inputs
     = f.input :name
-    = f.input :public_key, as: :string
     = f.input :private_key,
               as: :password,
               input_html: { value: f.object.private_key }

--- a/app/views/nostr_users/_nostr_user.html.slim
+++ b/app/views/nostr_users/_nostr_user.html.slim
@@ -8,9 +8,6 @@
         = nostr_user.name
 
     span.text-sm.text-gray-500
-      = nostr_user.public_key
-
-    span.text-sm.text-gray-500
       | *********
 
     span.text-sm.text-gray-500

--- a/db/migrate/20230808161207_remove_public_key_from_nostr_user.rb
+++ b/db/migrate/20230808161207_remove_public_key_from_nostr_user.rb
@@ -1,0 +1,5 @@
+class RemovePublicKeyFromNostrUser < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :nostr_users, :public_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_08_071551) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_08_161207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,7 +65,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_08_071551) do
 
   create_table "nostr_users", force: :cascade do |t|
     t.string "name"
-    t.string "public_key"
     t.string "private_key"
     t.string "relay_url"
     t.integer "language", null: false
@@ -74,7 +73,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_08_071551) do
     t.integer "stories_count", default: 0, null: false
     t.boolean "enabled", default: true, null: false
     t.index ["private_key"], name: "index_nostr_users_on_private_key", unique: true
-    t.index ["public_key"], name: "index_nostr_users_on_public_key", unique: true
   end
 
   create_table "stories", force: :cascade do |t|


### PR DESCRIPTION
This key is not mandatory to be handled in the database as it can be read directly from the private key (thanks to `nostr_ruby` gem)