### PR TITLE
Remove story from view after destroy commit

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -34,7 +34,12 @@ class StoriesController < ApplicationController
   def destroy
     NostrJobs::StoryDeletionJob.perform_later(@story)
 
-    redirect_to root_path, notice: "L'aventure est en cours de suppression"
+    respond_to do |format|
+      notice = "L'aventure est en cours de suppression"
+
+      format.html { redirect_to root_path, notice: notice }
+      format.turbo_stream { flash.now[:notice] = notice }
+    end
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,10 @@
 module ApplicationHelper
   include Pagy::Frontend
 
+  def render_turbo_stream_flash_messages
+    turbo_stream.prepend 'flashes', partial: 'flashes'
+  end
+
   def nostr_client_chapter_url(chapter)
     "#{nostr_client_url}/e/#{chapter.nostr_identifier}"
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -22,6 +22,10 @@ class Story < ApplicationRecord
     broadcast_prepend_to :stories
   end
 
+  after_destroy_commit do
+    broadcast_remove_to :stories
+  end
+
   scope :currents, -> { where(adventure_ended_at: nil) }
   scope :ended, -> { where.not(adventure_ended_at: nil) }
   scope :enabled, -> { where(enabled: true) }

--- a/app/views/stories/destroy.turbo_stream.slim
+++ b/app/views/stories/destroy.turbo_stream.slim
@@ -1,0 +1,1 @@
+= render_turbo_stream_flash_messages


### PR DESCRIPTION
After story has been removed from database, broadcast a turbo event to remove it from HTML dom as well.