### PR TITLE
Fix language use in ChatGPT system prompt instruction

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
-  def self.human_enum_name(enum_name, enum_value)
-    I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}")
+  def self.human_enum_name(enum_name, enum_value, locale: I18n.locale)
+    I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}", locale: locale)
   end
 end

--- a/app/services/chatgpt_complete_service.rb
+++ b/app/services/chatgpt_complete_service.rb
@@ -16,6 +16,8 @@ class ChatgptCompleteService < ChatgptService
     JSON.parse(response.results.first.content)
   end
 
+  private
+
   def messages
     array = [
       { role: 'system', content: system_prompt }
@@ -28,15 +30,13 @@ class ChatgptCompleteService < ChatgptService
 
   def system_prompt
     <<~STRING.strip
-      You act as a story book adventure narrator. The adventure should be epic with elaborated scenario and plot twist. Make chapter from around ten paragraphs each, only in #{language} language. For each chapter, choose a list of two options and then choose randomly one to be the prompt of the next chapter.
+      You act as a story book adventure narrator. The adventure should be epic with elaborated scenario and plot twist. Make chapter from around ten paragraphs each, only in #{Story.human_enum_name(:language, language, locale: :en)}language. For each chapter, choose a list of two options and then choose randomly one to be the prompt of the next chapter.
 
       Provide a RFC 8259 compliant JSON response following this format without deviation:
 
       #{json_format.to_json}
     STRING
   end
-
-  private
 
   def json_format
     {

--- a/app/services/chatgpt_dropper_service.rb
+++ b/app/services/chatgpt_dropper_service.rb
@@ -24,6 +24,8 @@ class ChatgptDropperService < ChatgptService
     json
   end
 
+  private
+
   def messages
     array = [
       { role: 'system', content: system_prompt }
@@ -41,15 +43,13 @@ class ChatgptDropperService < ChatgptService
 
   def system_prompt
     <<~STRING.strip
-      You act as a story book adventure narrator. The adventure should be progressive, generated one chapter at a time with a set of proposed options to continue the adventure. You reply in #{language} only. Use "adventure_ended" boolean to inform that the story is considered as completed.
+      You act as a story book adventure narrator. The adventure should be progressive, generated one chapter at a time with a set of proposed options to continue the adventure. You reply in #{Story.human_enum_name(:language, language, locale: :en)} only. Use "adventure_ended" boolean to inform that the story is considered as completed.
 
       Provide a RFC 8259 compliant JSON response following this format without deviation:
 
       #{json_format.to_json}
     STRING
   end
-
-  private
 
   def json_format
     {

--- a/config/locales/actverecord.en.yml
+++ b/config/locales/actverecord.en.yml
@@ -1,0 +1,7 @@
+en:
+  activerecord:
+    attributes:
+      story:
+        languages:
+          fr: French
+          en: English


### PR DESCRIPTION
Follow #5

After refactoring the language from complete name to ISO 639-1 format, the ChatGPT prompt was missed. Now the system prompt read the corresponding full language name, for better IA understanding.