### PR TITLE
Add variants for `Story` and `Chapter` ActiveStorage cover

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'bootsnap', require: false
 gem 'dotenv-rails'
 gem 'faker'
 gem 'human_attributes'
+gem 'image_processing'
 gem 'importmap-rails'
 gem 'jbuilder'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
     faraday-net_http (3.0.2)
     faraday-retry (2.2.0)
       faraday (~> 2.0)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
@@ -135,6 +136,9 @@ GEM
       rails (>= 4.2.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -167,6 +171,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.19.0)
     msgpack (1.7.2)
@@ -288,6 +293,8 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     ruby-next-core (0.15.3)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
@@ -380,6 +387,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   human_attributes
+  image_processing
   importmap-rails
   jbuilder
   letter_opener

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,9 +1,8 @@
 class Chapter < ApplicationRecord
+  include Coverable
   include NSFWCoverable
 
   belongs_to :story, counter_cache: true, touch: true
-
-  has_one_attached :cover
 
   after_create_commit do
     ReplicateServices::Picture.call(self, summary, publish: publish)
@@ -43,12 +42,6 @@ class Chapter < ApplicationRecord
   def broadcast_chapter
     broadcast_replace_to :chapters,
                          locals: { chapter_counter: story.chapters.count }
-  end
-
-  def replicate_cover
-    replicate_raw_response_body['data']['output'].first
-  rescue StandardError
-    nil
   end
 
   # Simulate the most voted option waiting to implement

--- a/app/models/concerns/coverable.rb
+++ b/app/models/concerns/coverable.rb
@@ -1,0 +1,17 @@
+module Coverable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one_attached :cover do |attachable|
+      attachable.variant :thumb, resize_to_limit: [100, 100]
+      attachable.variant :small, resize_to_limit: [300, 300]
+    end
+  end
+
+  # TODO: Use ActiveStorage version in production
+  def replicate_cover
+    replicate_raw_response_body['data']['output'].first
+  rescue StandardError
+    nil
+  end
+end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,4 +1,5 @@
 class Story < ApplicationRecord
+  include Coverable
   include NSFWCoverable
 
   enum mode: { complete: 0, dropper: 1 }
@@ -11,8 +12,6 @@ class Story < ApplicationRecord
   humanize :language, enum: true
 
   has_many :chapters, dependent: :destroy
-
-  has_one_attached :cover
 
   before_validation :assign_nostr_user, on: :create
 
@@ -72,12 +71,6 @@ class Story < ApplicationRecord
                              en: Story.publishable.en.first
                            }
                          }
-  end
-
-  def replicate_cover
-    replicate_raw_response_body['data']['output'].first
-  rescue StandardError
-    nil
   end
 
   def thematic_name

--- a/app/views/chapters/_chapter.html.slim
+++ b/app/views/chapters/_chapter.html.slim
@@ -4,7 +4,7 @@ details.cursor-pointer.mb-2.bg-gray-100.rounded-lg.transition-all class=('opacit
       span.text-gray-600 ##{chapter.position}
 
       - if chapter.cover.attached?
-        = image_tag url_for(chapter.cover), class: 'w-12 rounded-lg'
+        = image_tag url_for(chapter.cover.variant(:thumb)), class: 'w-12 rounded-lg'
       = chapter.title
 
     .flex.items-center.gap-3
@@ -44,7 +44,7 @@ details.cursor-pointer.mb-2.bg-gray-100.rounded-lg.transition-all class=('opacit
   .p-2
     .flex.flex-col.lg:flex-row.gap-3.mb-3
       - if chapter.cover.attached?
-        = image_tag url_for(chapter.cover), class: 'w-full lg:w-72 object-cover rounded-lg'
+        = image_tag url_for(chapter.cover.variant(:small)), class: 'w-full lg:w-72 object-cover rounded-lg'
 
       == chapter.content
 

--- a/app/views/homes/_stories.html.slim
+++ b/app/views/homes/_stories.html.slim
@@ -17,7 +17,7 @@ ul.divide-y.divide-gray-200#quick_look role="list"
 
       li.p-4.hover:bg-gray-100.transition-colors.flex.flex-col.lg:flex-row.items-center.justify-between.gap-6
         .flex.flex-col.lg:flex-row.items-center.gap-6.w-full
-          = image_tag polymorphic_path(story.cover), class: 'w-48 rounded-lg' if story.cover.attached?
+          = image_tag polymorphic_path(story.cover.variant(:small)), class: 'w-48 rounded-lg' if story.cover.attached?
 
           .w-full
             p.text-lg.font-bold.text-gray-900.truncate.mb-1
@@ -27,7 +27,7 @@ ul.divide-y.divide-gray-200#quick_look role="list"
 
             .flex.flex-col.lg:flex-row.items-center.gap-3.p-2.bg-gray-100.rounded-lg.border.border-gray-300
               - if active_chapter.cover.attached?
-                p.flex-none= image_tag polymorphic_path(active_chapter.cover), class: 'w-40 rounded-lg'
+                p.flex-none= image_tag polymorphic_path(active_chapter.cover.variant(:small)), class: 'w-40 rounded-lg'
 
               div
                 p.text-gray-500.font-bold

--- a/app/views/stories/_cover.html.slim
+++ b/app/views/stories/_cover.html.slim
@@ -1,1 +1,1 @@
-= image_tag polymorphic_path(story.cover), class: 'w-72 rounded-lg mb-3 border-2' if story.cover.attached?
+= image_tag polymorphic_path(story.cover.variant(:small)), class: 'w-72 rounded-lg mb-3 border-2' if story.cover.attached?


### PR DESCRIPTION
- Use `thumb` and `small` variant to resize uploaded covers
- Extract code into a new `Coverable` concern