### PR TITLE
Add action to refresh `nostr_user` metadata

### DIFF
--- a/app/controllers/nostr_users/refresh_profiles_controller.rb
+++ b/app/controllers/nostr_users/refresh_profiles_controller.rb
@@ -1,0 +1,20 @@
+module NostrUsers
+  class RefreshProfilesController < ApplicationController
+    before_action :set_nostr_user
+
+    # @route POST /nostr_users/:id/refresh_profiles (refresh_profiles)
+    def create
+      response = NostrServices::FetchProfile.call(@nostr_user)
+
+      @nostr_user.update(metadata_response: response)
+
+      redirect_to nostr_users_path, notice: 'Les métadonnées du profil ont bien été rafraîchies'
+    end
+
+    private
+
+    def set_nostr_user
+      @nostr_user = NostrUser.find(params[:id])
+    end
+  end
+end

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,2 +1,2 @@
-.flash__message.p-4.my-4.text-sm.rounded-xl.overflow-y-auto class="#{flash_type == 'notice' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'}"
+.flash__message.p-4.mb-4.text-sm.rounded-xl.overflow-y-auto class="#{flash_type == 'notice' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'}"
   = message

--- a/app/views/nostr_users/_nostr_user.html.slim
+++ b/app/views/nostr_users/_nostr_user.html.slim
@@ -18,3 +18,8 @@
 
     .flex.mt-4.space-x-3.md:mt-6
       = link_to 'Modifier', edit_nostr_user_path(nostr_user), class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-gray-900 bg-white border border-gray-300 rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-200'
+
+      = button_to 'Rafraîchir les métadonnées',
+                  refresh_profiles_path(nostr_user),
+                  class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-gray-900 bg-orange-500 border border-orange-300 rounded-lg hover:bg-orange-100 focus:ring-4 focus:outline-none focus:ring-orange-200',
+                  data: { turbo_confirm: 'Voulez-vous rafraîchir les métadonnées ?' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,14 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :nostr_users, except: :show
+  resources :nostr_users, except: :show do
+    scope module: :nostr_users do
+      member do
+        resource :refresh_profiles, only: :create
+      end
+    end
+  end
+
   resources :relays, except: :show
   resources :thematics
 end


### PR DESCRIPTION
If metadata have changed on remote relays, this new action will refresh old data.