### PR TITLE
Many UX improvements

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -19,7 +19,14 @@
 }
 
 /* Flash */
-#flash .flash__message {
+#flashes {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 21;
+}
+
+#flashes .flash__message {
   animation: appear-then-fade 10s both;
 }
 

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,4 +1,6 @@
 class HomesController < ApplicationController
+  helper_method :display_ended?
+
   # @route GET / (root)
   def show
     @stories = if display_ended?

--- a/app/controllers/replicate/webhooks_controller.rb
+++ b/app/controllers/replicate/webhooks_controller.rb
@@ -64,14 +64,8 @@ module Replicate
         end
       end
 
-      Turbo::StreamsChannel.broadcast_prepend_to(
-        :flashes,
-        target: 'flashes',
-        partial: 'flash',
-        locals: {
-          flash_type: 'alert',
-          message: "[#{e.class}] #{I18n.l(Time.current)} :: #{e.message}"
-        }
+      ApplicationRecord.broadcast_flash(
+        :alert, "[#{e.class}] #{I18n.l(Time.current)} :: #{e.message}"
       )
     end
   end

--- a/app/javascript/controllers/removals_controller.js
+++ b/app/javascript/controllers/removals_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  remove() {
+    this.element.remove()
+  }
+}

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,26 +4,10 @@ class ApplicationJob < ActiveJob::Base
   private
 
   def broadcast_flash_alert(e)
-    Turbo::StreamsChannel.broadcast_prepend_to(
-      :flashes,
-      target: 'flashes',
-      partial: 'flash',
-      locals: {
-        flash_type: 'alert',
-        message: "#{e.message} // #{e.backtrace}"
-      }
-    )
+    ApplicationRecord.broadcast_flash(:alert, e.message)
   end
 
   def broadcast_flash_notice(message)
-    Turbo::StreamsChannel.broadcast_prepend_to(
-      :flashes,
-      target: 'flashes',
-      partial: 'flash',
-      locals: {
-        flash_type: 'notice',
-        message: message
-      }
-    )
+    ApplicationRecord.broadcast_flash(:notice, message)
   end
 end

--- a/app/jobs/generate_full_story_job.rb
+++ b/app/jobs/generate_full_story_job.rb
@@ -7,6 +7,9 @@ class GenerateFullStoryJob < ApplicationJob
   def perform(language, thematic = nil, publish: false)
     thematic ||= Thematic.enabled.sample
 
+    Story.broadcast_flash(:notice, "Génération et publication complète d'une nouvelle aventure")
+    Story.display_placeholder
+
     description = thematic.send("description_#{language}")
     prompt = I18n.t('begin_adventure', description: description)
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,4 +4,16 @@ class ApplicationRecord < ActiveRecord::Base
   def self.human_enum_name(enum_name, enum_value, locale: I18n.locale)
     I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}", locale: locale)
   end
+
+  def self.broadcast_flash(type, message)
+    Turbo::StreamsChannel.broadcast_prepend_to(
+      :flashes,
+      target: 'flashes',
+      partial: 'flash',
+      locals: {
+        flash_type: type.to_s,
+        message: message
+      }
+    )
+  end
 end

--- a/app/services/nostr_publisher_service.rb
+++ b/app/services/nostr_publisher_service.rb
@@ -8,6 +8,8 @@ class NostrPublisherService < ApplicationService
   def call
     validate!
 
+    @publishable = story.publishable_story?
+
     I18n.with_locale(story.language) do
       process!
     end
@@ -53,7 +55,9 @@ class NostrPublisherService < ApplicationService
 
   def finish
     chapter.broadcast_chapter
-    story.broadcast_next_quick_look_story if story.publishable_story?
+    story.broadcast_move_from_current_to_ended if story.ended?
+    story.broadcast_next_quick_look_story if @publishable || story.ended?
+    story.display_empty_stories unless Story.current?
   end
 
   def story

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,2 +1,2 @@
-.flash__message.p-4.mb-4.text-sm.rounded-xl.overflow-y-auto class="#{flash_type == 'notice' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'}"
+.flash__message.p-4.mb-4.text-sm.rounded-xl.overflow-y-auto class="#{flash_type == 'notice' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'}" data-controller="removals" data-action="animationend->removals#remove"
   = message

--- a/app/views/chapters/_chapter.html.slim
+++ b/app/views/chapters/_chapter.html.slim
@@ -5,6 +5,11 @@ details.cursor-pointer.mb-2.bg-gray-100.rounded-lg.transition-all class=('opacit
 
       - if chapter.cover.attached?
         = image_tag url_for(chapter.cover.variant(:thumb)), class: 'w-12 rounded-lg'
+      - else
+        .flex.items-center.justify-center.w-10.h-6.bg-gray-700.rounded.animate-pulse
+          svg.w-10.h-10.text-gray-200 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18"
+            path d="M18 0H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2Zm-5.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3Zm4.376 10.481A1 1 0 0 1 16 15H4a1 1 0 0 1-.895-1.447l3.5-7A1 1 0 0 1 7.468 6a.965.965 0 0 1 .9.5l2.775 4.757 1.546-1.887a1 1 0 0 1 1.618.1l2.541 4a1 1 0 0 1 .028 1.011Z"
+
       = chapter.title
 
     .flex.items-center.gap-3

--- a/app/views/homes/_empty_stories.html.slim
+++ b/app/views/homes/_empty_stories.html.slim
@@ -1,0 +1,2 @@
+.bg-red-100.border.border-red-200.rounded-lg.p-2
+  p Il n'y a pas encore d'histoire

--- a/app/views/homes/_quick_look_active_stories.html.slim
+++ b/app/views/homes/_quick_look_active_stories.html.slim
@@ -1,8 +1,7 @@
 = turbo_stream_from :active_stories
 
 - if stories.present?
-  .w-full.bg-white.border.border-gray-200.rounded-lg.shadow.mb-2
-    .flow-root
-      = render 'homes/stories', stories: stories
+  .w-full.bg-white.rounded-lg.shadow.mb-2
+    = render 'homes/stories', stories: stories
 
   p.italic.text-sm.text-gray-500 Ces aventures sont celles utilisées par la publication automatisée

--- a/app/views/homes/_stories.html.slim
+++ b/app/views/homes/_stories.html.slim
@@ -1,16 +1,16 @@
-ul.divide-y.divide-gray-200#quick_look role="list"
+ul#quick_look role="list"
   - stories.each do |language, story|
     - if story.nil?
-      li.p-4
-        .flex.items-center.gap-6
-          .flex-1.min-w-0
-            p.bg-green-500.p-2.rounded-lg.italic.text-white Une nouvelle aventure sera créée à la prochaine exécution de la tâche
+      li.bg-green-500.px-4.py-2.rounded-lg.italic.text-white.mb-1
+        - nostr_user = NostrUser.find_sole_by(language: language)
 
-          .text-base.font-semibold.text-gray-900
-            - nostr_user = NostrUser.find_sole_by(language: language)
+        .flex.items-center.gap-3
+          div
             - if nostr_user.picture
-              = image_tag nostr_user.picture, class: 'w-24 mx-auto mb-1 rounded-full'
-            p= nostr_user.name
+              = image_tag nostr_user.picture, class: 'w-12 mx-auto mb-1 rounded-full'
+          div
+            p Une nouvelle aventure sera créée à la prochaine exécution de la tâche
+            p.text-xs= nostr_user.name
 
     - else
       - active_chapter = story.chapters.not_published.first

--- a/app/views/homes/show.html.slim
+++ b/app/views/homes/show.html.slim
@@ -1,6 +1,11 @@
 = turbo_stream_from :stories
 = turbo_stream_from :chapters
 
+- if display_ended?
+  = turbo_stream_from %i[stories ended]
+- else
+  = turbo_stream_from %i[stories current]
+
 - if allowed_to?(:create?, Story)
   details.bg-gray-200.rounded-lg.mb-6
     summary.p-2.cursor-pointer Générateur d'aventures
@@ -8,13 +13,13 @@
 
 header.flex.flex-col.lg:flex-row.justify-between.items-center.mb-8
   h1.text-3xl
-    - if params[:display_ended].to_bool
+    - if display_ended?
       | Les aventures terminées
     - else
       | Les aventures en cours
 
   p.text-sm
-    - if params[:display_ended].to_bool
+    - if display_ended?
       = link_to 'Voir les aventures en cours', root_path, class: 'underline'
     - else
       = link_to 'Voir les aventures terminées', root_path(display_ended: true), class: 'underline'
@@ -36,10 +41,10 @@ section.mb-6
 
 == pagy_nav(@pagy) if @pagy.pages > 1
 
+#placeholder_story
 #stories= render @stories
 
 == pagy_nav(@pagy) if @pagy.pages > 1
 
-- if @stories.empty?
-  .bg-red-100.border.border-red-200.rounded-lg.p-2
-    p Il n'y a pas encore d'histoire
+#empty_stories
+  = render 'empty_stories' if @stories.empty?

--- a/app/views/stories/_cover.html.slim
+++ b/app/views/stories/_cover.html.slim
@@ -1,1 +1,6 @@
-= image_tag polymorphic_path(story.cover.variant(:small)), class: 'w-72 rounded-lg mb-3 border-2' if story.cover.attached?
+- if story.cover.attached?
+  = image_tag polymorphic_path(story.cover.variant(:small)), class: 'w-72 rounded-lg mb-3 border-2'
+- else
+  .flex.items-center.justify-center.w-72.h-72.bg-gray-700.rounded.animate-pulse.mb-3
+    svg.w-10.h-10.text-gray-200 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18"
+      path d="M18 0H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2Zm-5.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3Zm4.376 10.481A1 1 0 0 1 16 15H4a1 1 0 0 1-.895-1.447l3.5-7A1 1 0 0 1 7.468 6a.965.965 0 0 1 .9.5l2.775 4.757 1.546-1.887a1 1 0 0 1 1.618.1l2.541 4a1 1 0 0 1 .028 1.011Z"

--- a/app/views/stories/_placeholder.html.slim
+++ b/app/views/stories/_placeholder.html.slim
@@ -1,0 +1,14 @@
+.space-y-8.animate-pulse.md:space-y-0.md:space-x-8.md:flex.md:items-center.mb-6 role="status"
+  .flex.items-center.justify-center.w-full.h-48.bg-gray-300.rounded
+    svg.w-10.h-10.text-gray-200 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18"
+      path d="M18 0H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2Zm-5.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3Zm4.376 10.481A1 1 0 0 1 16 15H4a1 1 0 0 1-.895-1.447l3.5-7A1 1 0 0 1 7.468 6a.965.965 0 0 1 .9.5l2.775 4.757 1.546-1.887a1 1 0 0 1 1.618.1l2.541 4a1 1 0 0 1 .028 1.011Z"
+
+  .w-full
+    div class="h-2.5 bg-gray-200 rounded-full w-48 mb-4"
+    div class="h-2 bg-gray-200 rounded-full max-w-[480px] mb-2.5"
+    div class="h-2 bg-gray-200 rounded-full mb-2.5"
+    div class="h-2 bg-gray-200 rounded-full max-w-[440px] mb-2.5"
+    div class="h-2 bg-gray-200 rounded-full max-w-[460px] mb-2.5"
+    div class="h-2 bg-gray-200 rounded-full max-w-[360px]"
+
+  span.sr-only Chargement...

--- a/config/locales/cover_errors.en.yml
+++ b/config/locales/cover_errors.en.yml
@@ -1,4 +1,4 @@
 en:
   exceptions:
     cover_errors:
-      nsfw_detected: "NSFW cover detected, please generate it again [used prompt: %{prompt}] [prediction: %{prediction}]"
+      nsfw_detected: "NSFW cover detected, please generate it again [used prompt: %{prompt}]"

--- a/config/locales/cover_errors.fr.yml
+++ b/config/locales/cover_errors.fr.yml
@@ -1,4 +1,4 @@
 fr:
   exceptions:
     cover_errors:
-      nsfw_detected: "La couverture est NSFW, veuillez la générer à nouveau [prompt utilisé: %{prompt}] [prediction: %{prediction}]"
+      nsfw_detected: "La couverture est NSFW, veuillez la générer à nouveau [prompt utilisé: %{prompt}]"


### PR DESCRIPTION
Details:

- Make the frontend more reactive with Turbo stream:
  - when an adventure is ended, remove it from the current adventure view to ended view
  - when an adventure is ended and publishable, refresh the quick look view
  - display a placeholder when story is being generated
- Display stories and chapters cover placeholder image waiting replicate webhook
- Refactor flash messages to be triggered from the model
- Make flash messages fixed at the top/right of the screen
- Remove backtrace from exception as process is now more stable