### PR TITLE
Reorder relays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,5 +52,6 @@ end
 group :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  gem 'shoulda-matchers'
   gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,8 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     sidekiq (7.1.2)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
@@ -421,6 +423,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  shoulda-matchers
   sidekiq
   simple_form
   simplecov

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -70,3 +70,31 @@
     @apply text-white bg-primary-color;
   }
 }
+
+input.boolean {
+  @apply inline-block w-4 mr-2;
+}
+
+.error, .error_notification {
+  @apply text-red-500 italic text-sm;
+}
+
+.field_with_errors input {
+  @apply border-red-500;
+}
+
+.field_with_errors input:focus {
+  @apply border-red-500 ring-red-500;
+}
+
+.back-link {
+  @apply bg-gray-700 text-white text-sm px-2 py-1 rounded-lg;
+}
+
+.edit-link {
+  @apply back-link !bg-orange-700;
+}
+
+.destroy-button {
+  @apply back-link !bg-red-700;
+}

--- a/app/controllers/relays_controller.rb
+++ b/app/controllers/relays_controller.rb
@@ -5,7 +5,7 @@ class RelaysController < ApplicationController
   def index
     authorize! Relay
 
-    @relays = Relay.all
+    @relays = Relay.all.by_position
   end
 
   # @route GET /relays/new (new_relay)
@@ -22,7 +22,7 @@ class RelaysController < ApplicationController
     @relay = Relay.new(relay_params)
 
     if @relay.save
-      redirect_to relays_path, notice: 'Relay was successfully created.'
+      redirect_to relays_path, notice: 'Relay was successfully created.', status: :see_other
     else
       render :new, status: :unprocessable_entity
     end
@@ -38,10 +38,13 @@ class RelaysController < ApplicationController
   def update
     authorize! @relay
 
-    if @relay.update(relay_params)
-      redirect_to relays_path, notice: 'Relay was successfully updated.'
-    else
-      render :edit, status: :unprocessable_entity
+    respond_to do |format|
+      if @relay.update(relay_params)
+        format.html { redirect_to relays_path, notice: 'Relay was successfully updated.', status: :see_other }
+        format.turbo_stream if @relay.position_previously_changed?
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+      end
     end
   end
 
@@ -61,6 +64,6 @@ class RelaysController < ApplicationController
   end
 
   def relay_params
-    params.require(:relay).permit(:url, :description, :enabled)
+    params.require(:relay).permit(:url, :description, :enabled, :position)
   end
 end

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from '@hotwired/stimulus'
+import { patch } from '@rails/request.js'
+import Sortable from 'sortablejs'
+
+export default class extends Controller {
+  static classes = ['ghost', 'filter']
+  static values = { model: String }
+
+  connect() {
+    Sortable.create(this.element, {
+      animation: 150,
+      handle: '.handle',
+      ghostClass: this.ghostClass,
+      filter: `.${this.filterClass}`,
+      onEnd: this._updatePosition.bind(this)
+    })
+  }
+
+  _updatePosition(e) {
+    if (e.newIndex == e.oldIndex) {
+      return
+    }
+
+    const newPosition = e.newIndex + 1
+
+    let body = {}
+    body[this.modelValue] = { position: newPosition }
+
+    patch(e.item.dataset.sortableUrl, {
+      responseKind: 'turbo-stream',
+      body: body
+    })
+  }
+}

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -2,10 +2,14 @@ class Relay < ApplicationRecord
   has_many :nostr_users_relays, dependent: :destroy
   has_many :nostr_users, through: :nostr_users_relays
 
+  acts_as_list
+
   scope :enabled, -> { where(enabled: true) }
+  scope :by_position, -> { order(:position) }
 
   validates :url, presence: true, uniqueness: true
 
+  before_validation :clean_url
   after_update :delete_nostr_users_association, if: :marked_as_disabled?
 
   def title
@@ -13,6 +17,18 @@ class Relay < ApplicationRecord
   end
 
   private
+
+  def clean_url
+    return if url.blank?
+
+    cleaned_url = url.strip
+                     .delete_prefix('http://')
+                     .delete_prefix('https://')
+
+    cleaned_url = "wss://#{cleaned_url}" unless cleaned_url.starts_with?('ws://') || cleaned_url.starts_with?('wss://')
+
+    self.url = cleaned_url
+  end
 
   def delete_nostr_users_association
     nostr_users_relays.delete_all
@@ -33,6 +49,7 @@ end
 #  enabled     :boolean          default(TRUE), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  position    :integer          default(1), not null
 #
 # Indexes
 #

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -7,11 +7,12 @@ class Relay < ApplicationRecord
   scope :enabled, -> { where(enabled: true) }
   scope :by_position, -> { order(:position) }
 
-  validates :url, presence: true, uniqueness: true
+  validates :url, presence: true, uniqueness: { case_sensitive: false }
 
-  before_validation :clean_url
+  after_validation :clean_url
   after_update :delete_nostr_users_association, if: :marked_as_disabled?
 
+  # NOTE: title is used as alias to get correct form label association
   def title
     url
   end

--- a/app/services/nostr_event.rb
+++ b/app/services/nostr_event.rb
@@ -13,12 +13,12 @@ class NostrEvent < ApplicationService
     nostr_user.private_key
   end
 
-  def relay_url
+  def favorite_relay_url
     relay_urls.first
   end
 
   def relay_urls
-    nostr_user.relays.enabled.map(&:url)
+    nostr_user.relays.enabled.by_position.map(&:url)
   end
 
   def created_at

--- a/app/services/nostr_services/chapter_poll_event.rb
+++ b/app/services/nostr_services/chapter_poll_event.rb
@@ -40,12 +40,12 @@ module NostrServices
 
     def tags
       [
-        ['p', public_key],
+        ['p', public_key, favorite_relay_url],
         ['value_minimum', MINIMUM_SATS_VALUE.to_s],
         ['value_maximum', MAXIMUM_SATS_VALUE.to_s],
         ['closed_at', POLL_END_OF_LIFE.from_now.utc.to_i.to_s]
       ].tap do |data|
-        data.push ['e', reference] if reference
+        data.push ['e', reference, favorite_relay_url] if reference
 
         options.each_with_index do |option, index|
           data.push ['poll_option', index.to_s, option]

--- a/app/services/nostr_services/fetch_profile.rb
+++ b/app/services/nostr_services/fetch_profile.rb
@@ -11,7 +11,7 @@ module NostrServices
     def call
       req = nostr.build_req_event(filters)
 
-      test_post_event(req, relay_url)
+      test_post_event(req, favorite_relay_url)
     end
 
     private

--- a/app/services/nostr_services/text_note_event.rb
+++ b/app/services/nostr_services/text_note_event.rb
@@ -30,9 +30,9 @@ module NostrServices
 
     def tags
       [
-        ['p', public_key, '']
+        ['p', public_key, favorite_relay_url]
       ].tap do |data|
-        data.push ['e', reference, ''] if reference
+        data.push ['e', reference, favorite_relay_url] if reference
       end
     end
   end

--- a/app/views/relays/_form.html.slim
+++ b/app/views/relays/_form.html.slim
@@ -1,11 +1,15 @@
 = simple_form_for(@relay) do |f|
-  = f.error_notification
-  = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
-
   .form-inputs
-    = f.input :url
-    = f.input :description
-    = f.input :enabled
+    = f.input :url,
+              autofocus: true,
+              wrapper_html: { class: 'mb-5' }
+
+    = f.input :description,
+              input_html: { class: 'h-48' },
+              wrapper_html: { class: 'mb-5' }
+
+    = f.input :enabled,
+              wrapper_html: { class: 'mb-5' }
 
   .form-actions
     = f.button :submit

--- a/app/views/relays/_relay.html.slim
+++ b/app/views/relays/_relay.html.slim
@@ -1,16 +1,29 @@
-div id="#{dom_id relay}"
-  p
-    strong Url:
-    =< relay.url
-  p
-    strong Description:
-    =< relay.description
-  p
-    strong Enabled:
-    =< relay.enabled
+- favorite = false
 
-  - if allowed_to?(:update?, relay)
-    => link_to "Edit this relay", edit_relay_path(relay)
+- if relay.first? && relay.enabled?
+  - favorite = true
+- elsif Relay.enabled.by_position.first == relay
+  - favorite = true
 
-  - if allowed_to?(:destroy?, relay)
-    = button_to "Destroy this relay", relay, method: :delete
+details.border.mb-3.rounded-lg id=dom_id(relay) data-sortable-url=relay_path(relay) class=('opacity-50' unless relay.enabled?) class=(favorite ? 'border-green-300 bg-green-100' : 'border-gray-300 bg-gray-100')
+  summary.flex.items-center.gap-3.justify-between.p-2.relative
+    - if favorite
+      span.absolute.-top-3.-left-2 title="Relay favori" ⭐
+    .flex.items-center.gap-3
+      span.handle.cursor-move ↕️
+      span.font-bold ##{relay.position}
+
+      = relay.url
+
+    .flex.items-center.gap-3
+      - if allowed_to?(:update?, relay)
+        => link_to 'Modifier', edit_relay_path(relay), class: 'edit-link'
+
+      - if allowed_to?(:destroy?, relay)
+        = button_to 'Supprimer', relay,
+                    class: 'destroy-button',
+                    method: :delete,
+                    data: { turbo_confirm: 'Voulez-vous supprimer ce relay ?' }
+
+  .p-2
+    = relay.description

--- a/app/views/relays/edit.html.slim
+++ b/app/views/relays/edit.html.slim
@@ -1,10 +1,6 @@
-h1 Editing relay
+header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
+  h1.text-3xl Modifier relays
 
-== render "form", relay: @relay
+  = link_to '<< Retour', relays_path, class: 'back-link'
 
-br
-
-div
-  => link_to "Show this relay", @relay
-  '|
-  =< link_to "Back to relays", relays_path
+= render 'form', relay: @relay

--- a/app/views/relays/index.html.slim
+++ b/app/views/relays/index.html.slim
@@ -1,8 +1,8 @@
-h1 Relays
+header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
+  h1.text-3xl Les relays
 
-#relays
-  - @relays.each do |relay|
-    == render relay
+  - if allowed_to?(:create?, Relay)
+    = link_to 'Ajouter un relais', new_relay_path, class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-green-700 rounded-lg hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300'
 
-- if allowed_to?(:create?, Relay)
-  = link_to "New relay", new_relay_path
+#relays data-controller="sortable" data-sortable-ghost-class="bg-gray-200" data-sortable-filter-class="opacity-25" data-sortable-model-value="relay"
+  = render @relays

--- a/app/views/relays/new.html.slim
+++ b/app/views/relays/new.html.slim
@@ -1,8 +1,6 @@
-h1 New relay
+header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
+  h1.text-3xl Ajouter un relay
 
-== render "form", relay: @relay
+  = link_to '<< Retour', relays_path, class: 'back-link'
 
-br
-
-div
-  = link_to "Back to relays", relays_path
+= render 'form', relay: @relay

--- a/app/views/relays/update.turbo_stream.slim
+++ b/app/views/relays/update.turbo_stream.slim
@@ -1,0 +1,3 @@
+- if @relay.position_previously_changed?
+  = turbo_stream.update :relays do
+    = render Relay.all.by_position

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -3,18 +3,13 @@
 
   = simple_form_for :session, url: sessions_path do |f|
     = f.input :email,
-              label_html: { class: 'block mb-2' },
-              input_html: { class: 'w-full' },
               wrapper_html: { class: 'mb-5' },
               autofocus: true
 
     = f.input :password, as: :password,
-              label_html: { class: 'block mb-2' },
-              input_html: { class: 'w-full' },
               wrapper_html: { class: 'mb-5' }
 
     = f.input :remember, as: :boolean,
-              input_html: { class: 'mr-2' },
               wrapper_html: { class: 'mb-5' }
 
     .flex.justify-center.items-center

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,6 @@ pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
 pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
 pin_all_from 'app/javascript/controllers', under: 'controllers'
+
+pin '@rails/request.js', to: 'https://ga.jspm.io/npm:@rails/request.js@0.0.8/src/index.js'
+pin 'sortablejs', to: 'https://ga.jspm.io/npm:sortablejs@1.15.0/modular/sortable.esm.js'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -75,7 +75,7 @@ SimpleForm.setup do |config|
   config.boolean_style = :nested
 
   # Default class for buttons
-  config.button_class = 'btn'
+  config.button_class = 'bg-green-500 text-white p-2 rounded-lg cursor-pointer'
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
@@ -111,7 +111,7 @@ SimpleForm.setup do |config|
   # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
 
   # You can define the class to use on all labels. Default is nil.
-  # config.label_class = nil
+  config.label_class = 'block mb-2'
 
   # You can define the default class to be used on forms. Can be overridden
   # with `html: { :class }`. Defaulting to none.
@@ -159,7 +159,7 @@ SimpleForm.setup do |config|
   # config.cache_discovery = !Rails.env.development?
 
   # Default class for inputs
-  # config.input_class = nil
+  config.input_class = 'w-full'
 
   # Define the default class of the input wrapper of the boolean input.
   config.boolean_label_class = 'checkbox'

--- a/config/locales/actverecord.fr.yml
+++ b/config/locales/actverecord.fr.yml
@@ -12,3 +12,8 @@ fr:
         languages:
           fr: Français
           en: Anglais
+
+      relay:
+        url: WebSocket URL (ws:// ou wss://)
+        description: Description
+        enabled: Activé ?

--- a/db/migrate/20230811073858_add_position_to_relays.rb
+++ b/db/migrate/20230811073858_add_position_to_relays.rb
@@ -1,0 +1,5 @@
+class AddPositionToRelays < ActiveRecord::Migration[7.0]
+  def change
+    add_column :relays, :position, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_09_170858) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_11_073858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_170858) do
     t.boolean "enabled", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position", default: 1, null: false
     t.index ["url"], name: "index_relays_on_url", unique: true
   end
 

--- a/spec/factories/relays.rb
+++ b/spec/factories/relays.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :relay do
+    sequence(:url) { |n| "wss://relay#{n}.test" }
+  end
+end

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Relay do
+  it { is_expected.to validate_presence_of(:url) }
+  it { is_expected.to validate_uniqueness_of(:url).case_insensitive }
+
+  describe '#title' do
+    subject { relay.title }
+
+    let(:relay) { build :relay, url: 'wss://relay.test' }
+
+    it { is_expected.to eq 'wss://relay.test' }
+  end
+
+  describe '#url' do
+    subject { relay.url }
+
+    let(:relay) { build :relay, url: url }
+
+    before { relay.valid? }
+
+    context 'when url has spaces before and after' do
+      let(:url) { '  wss://relay.test    ' }
+
+      it { is_expected.to eq 'wss://relay.test' }
+    end
+
+    context 'when url starts with ws://' do
+      let(:url) { 'ws://relay.test' }
+
+      it { is_expected.to eq 'ws://relay.test' }
+    end
+
+    context 'when url starts with wss://' do
+      let(:url) { 'wss://relay.test' }
+
+      it { is_expected.to eq 'wss://relay.test' }
+    end
+
+    context 'when url starts with http://' do
+      let(:url) { 'http://relay.test' }
+
+      it { is_expected.to eq 'wss://relay.test' }
+    end
+
+    context 'when url starts with https://' do
+      let(:url) { 'https://relay.test' }
+
+      it { is_expected.to eq 'wss://relay.test' }
+    end
+
+    context 'when url does not specify protocol' do
+      let(:url) { 'relay.test' }
+
+      it { is_expected.to eq 'wss://relay.test' }
+    end
+  end
+end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
This new feature allows to reorder the relay list by drag and drop.
First relay is considered as the favorite one and is set as the recommended relay
to `p` and `e` tags in an event.

Details:
- Add `sortablejs` lib and a dedicated stimulus controller
- Add `@rails/request.js` package to perform ajax calls
- Enhance design rendering of relay scaffold (general content and form errors)
- Update SimpleForm configuration to add css classes by default
- Adds the `shoulda-matchers` gem for easier validation process for testing relays