### PR TITLE
Respond with `turbo-stream` on chapter published

### DIFF
--- a/app/controllers/stories/chapters_controller.rb
+++ b/app/controllers/stories/chapters_controller.rb
@@ -44,7 +44,12 @@ module Stories
 
       NostrJobs::SinglePublisherJob.perform_later(@chapter)
 
-      redirect_to root_path, notice: 'Le chapitre est en cours de publication sur Nostr'
+      respond_to do |format|
+        notice = 'Le chapitre est en cours de publication sur Nostr'
+
+        format.html { redirect_to root_path, notice: notice }
+        format.turbo_stream { flash.now[:notice] = notice }
+      end
     end
 
     # @route POST /stories/:story_id/chapters/publish_all (publish_all_story_chapters)
@@ -53,7 +58,12 @@ module Stories
 
       NostrJobs::AllPublisherJob.perform_later(@story)
 
-      redirect_to root_path, notice: 'Tous les chapitres sont en cours de publication sur Nostr'
+      respond_to do |format|
+        notice = 'Tous les chapitres sont en cours de publication sur Nostr'
+
+        format.html { redirect_to root_path, notice: notice }
+        format.turbo_stream { flash.now[:notice] = notice }
+      end
     end
 
     # @route POST /stories/:story_id/chapters/:id/publish (publish_story_chapter)
@@ -62,7 +72,12 @@ module Stories
 
       NostrJobs::SinglePublisherJob.perform_later(@chapter)
 
-      redirect_to root_path, notice: 'Le chapitre est en cours de publication sur Nostr'
+      respond_to do |format|
+        notice = 'Le chapitre est en cours de publication sur Nostr'
+
+        format.html { redirect_to root_path, notice: notice }
+        format.turbo_stream { flash.now[:notice] = notice }
+      end
     end
 
     private

--- a/app/views/stories/chapters/publish.turbo_stream.slim
+++ b/app/views/stories/chapters/publish.turbo_stream.slim
@@ -1,0 +1,1 @@
+= render_turbo_stream_flash_messages

--- a/app/views/stories/chapters/publish_all.turbo_stream.slim
+++ b/app/views/stories/chapters/publish_all.turbo_stream.slim
@@ -1,0 +1,1 @@
+= render_turbo_stream_flash_messages

--- a/app/views/stories/chapters/publish_next.turbo_stream.slim
+++ b/app/views/stories/chapters/publish_next.turbo_stream.slim
@@ -1,0 +1,1 @@
+= render_turbo_stream_flash_messages


### PR DESCRIPTION
When a chapter is published from the frontend interface, respond with `turbo-stream` instead of `html` to spare resources and avoid redirecting the page.

Now working for `#publish_next`, `#publish_all` and `#publish` actions.