### PR TITLE
Refactor stories creation

### DIFF
--- a/app/controllers/stories/chapters_controller.rb
+++ b/app/controllers/stories/chapters_controller.rb
@@ -16,7 +16,7 @@ module Stories
         ChapterErrors::EmptyPollOptions,
         ChapterErrors::MissingPollOptions
       ) do
-        @json = ChatgptDropperService.call(prompt, @story.language, @story)
+        @json = ChatgptDropperService.call(prompt, @story.nostr_user.language, @story)
       end
 
       ApplicationRecord.transaction do

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,12 +3,16 @@ class ApplicationJob < ActiveJob::Base
 
   private
 
-  def broadcast_flash_alert(e, show_backtrace: false)
-    message = "[#{e.class.name}] #{e.message} #{e.backtrace if show_backtrace}"
+  def broadcast_flash_alert(e)
+    message = "[#{e.class.name}] #{e.message}"
 
     Rails.logger.tagged(e.class) do
       Rails.logger.error do
-        ActiveSupport::LogSubscriber.new.send(:color, message, :red)
+        ActiveSupport::LogSubscriber.new.send(
+          :color,
+          "#{message} // #{e.backtrace}",
+          :red
+        )
       end
     end
 

--- a/app/jobs/generate_full_story_job.rb
+++ b/app/jobs/generate_full_story_job.rb
@@ -1,56 +1,58 @@
 class GenerateFullStoryJob < ApplicationJob
   # TODO: Validate that a nostr_user is enabled for a language or raise
   # TODO: Validate that thematic is properly enabled or raise
-  # @param nostr_user [NostrUser] nostr user choosed to publish story
-  # @param thematic [Thematic|NilClass] Story's thematic or nil
+  # @param draft_story [Story] draft story to generate
   # @param publish [Boolean] Should the {Chapter} be published ?
-  def perform(nostr_user, thematic = nil, publish: false)
-    thematic ||= Thematic.enabled.sample
+  def perform(draft_story, publish: false)
+    nostr_user = draft_story.nostr_user
 
-    Story.broadcast_flash(:notice, "Génération et publication complète d'une nouvelle aventure")
-    Story.display_placeholder
+    flash_message = <<~CONTENT
+      - Mode: <strong>#{draft_story.human_mode}</strong>
+      - Thèmatique: <strong>#{draft_story.thematic_name}</strong>
+      - Compte Nostr: <strong>#{nostr_user.profile.identity}</strong>
+      - Langue: <strong>#{nostr_user.human_language}</strong>
+    CONTENT
 
-    description = thematic.send("description_#{nostr_user.language.downcase}")
-    prompt = I18n.t('begin_adventure', description: description)
+    Story.broadcast_flash(:notice, flash_message)
+
+    prompt = I18n.t('begin_adventure', description: draft_story.thematic_description)
 
     Retry.on(
       Net::ReadTimeout,
       JSON::ParserError,
-      ChapterErrors::FullStoryMissingChapters,
-      times: 5
+      ChapterErrors::FullStoryMissingChapters
     ) do
       @json = ChatgptCompleteService.call(prompt, nostr_user.language)
 
       raise ChapterErrors::FullStoryMissingChapters if @json['chapters'].count < 3
     end
 
+    Story.broadcast_flash(:notice, <<~CONTENT)
+      L'aventure <strong>#{@json['title']}</strong> vient d'être générée avec <strong>#{@json['chapters'].count} chapitres</strong>.
+    CONTENT
+
     ApplicationRecord.transaction do
-      @story = Story.create!(
+      story_accurate_cover_prompt = ChatgptSummaryService.call("#{@json['title']}, #{draft_story.thematic_description}")
+
+      draft_story.update!(
         title: @json['title'],
-        adventure_ended_at: nil,
         raw_response_body: @json,
-        mode: :complete,
-        thematic: thematic,
-        nostr_user: nostr_user
+        summary: story_accurate_cover_prompt
       )
 
-      # Call ChatGPT to make an accurate story summary
-      story_cover_prompt = ChatgptSummaryService.call("#{@story.title}, #{description}")
-      @story.update(summary: story_cover_prompt)
-
       @json['chapters'].each_with_index do |row, index|
-        @chapter = @story.chapters.create!(
+        chapter_accurate_cover_prompt = ChatgptSummaryService.call(row['content'])
+
+        draft_story.chapters.create!(
           title: row['title'],
           content: row['content'],
-          summary: row['summary'],
+          summary: chapter_accurate_cover_prompt,
           chat_raw_response_body: row,
           publish: publish == :all || (publish && index.zero?)
         )
-
-        # Call ChatGPT to make an accurate chapter summary
-        chapter_cover_prompt = ChatgptSummaryService.call(@chapter.content)
-        @chapter.update(summary: chapter_cover_prompt)
       end
+
+      draft_story.completed!
     end
   end
 end

--- a/app/models/thematic.rb
+++ b/app/models/thematic.rb
@@ -6,6 +6,10 @@ class Thematic < ApplicationRecord
   validates :description_fr, presence: true
   validates :description_en, presence: true
   validates :identifier, presence: true, uniqueness: true
+
+  def name
+    name_fr
+  end
 end
 
 # == Schema Information

--- a/app/services/chatgpt_dropper_service.rb
+++ b/app/services/chatgpt_dropper_service.rb
@@ -69,7 +69,7 @@ class ChatgptDropperService < ChatgptService
   def chapters
     return [] if story.nil?
 
-    story.chapters.last(8)
+    story.chapters.by_position.last(8)
   end
 
   def reminder

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,2 +1,2 @@
 .flash__message.p-4.mb-4.text-sm.rounded-xl.overflow-y-auto class="#{flash_type == 'notice' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'}" data-controller="removals" data-action="animationend->removals#remove"
-  = message
+  = simple_format message

--- a/app/views/application/_quick_custom_story_generator.html.slim
+++ b/app/views/application/_quick_custom_story_generator.html.slim
@@ -1,16 +1,16 @@
-= simple_form_for :story,
+= simple_form_for Story.new,
                   url: stories_path,
                   html: { \
-                    class: 'flex flex-col lg:flex-row items-center gap-3 justify-between p-4 border-t border-gray-300' \
+                    class: 'flex flex-col lg:flex-row items-center gap-3 justify-between p-4 bg-gray-200 rounded-b-lg' \
                   } do |f|
 
   .flex.flex-col.lg:flex-row.items-start.gap-3.justify-between
-    = f.input :thematic_id,
-              collection: Thematic.enabled.map { |t| [t.name_fr, t.id] },
-              include_blank: '[Aléatoire]',
-              label_html: { class: 'block italic mb-2' },
-              input_html: { class: 'w-full' },
-              wrapper_html: { class: 'text-center w-full' }
+    = f.association :thematic,
+                    collection: Thematic.enabled,
+                    include_blank: '[Aléatoire]',
+                    label_html: { class: 'block italic mb-2' },
+                    input_html: { class: 'w-full' },
+                    wrapper_html: { class: 'text-center w-full' }
 
     = f.input :mode,
               collection: select_options_for(Story, :modes),
@@ -19,12 +19,12 @@
               input_html: { class: 'w-full' },
               wrapper_html: { class: 'text-center w-full' }
 
-    = f.input :nostr_user_id,
-              collection: story_nostr_users_select_options,
-              include_blank: false,
-              label_html: { class: 'block italic mb-2' },
-              input_html: { class: 'w-full' },
-              wrapper_html: { class: 'text-center w-full' }
+    = f.association :nostr_user,
+                    collection: story_nostr_users_select_options,
+                    include_blank: false,
+                    label_html: { class: 'block italic mb-2' },
+                    input_html: { class: 'w-full' },
+                    wrapper_html: { class: 'text-center w-full' }
 
   = f.button :submit, 'Créer une aventure sur mesure',
              class: 'bg-green-600 p-2 rounded-lg text-white cursor-pointer'

--- a/app/views/homes/show.html.slim
+++ b/app/views/homes/show.html.slim
@@ -7,8 +7,8 @@
   = turbo_stream_from %i[stories current]
 
 - if allowed_to?(:create?, Story) && !display_ended?
-  details.bg-gray-200.rounded-lg.mb-6
-    summary.p-2.cursor-pointer Générateur d'aventures
+  details.bg-gray-200.mb-6.border.border-primary-color.rounded-lg open="open"
+    summary.bg-primary-color.text-white.p-2.cursor-pointer.rounded-lg Générateur d'aventures
     = render 'quick_custom_story_generator', stories: @active_stories
 
 header.flex.flex-col.lg:flex-row.justify-between.items-center.mb-8

--- a/app/views/stories/_story.html.slim
+++ b/app/views/stories/_story.html.slim
@@ -1,33 +1,37 @@
-.flex.flex-col.lg:flex-row.justify-between.mb-6 class=('opacity-75' unless story.enabled?) class="lg:max-h-[30rem]" id=dom_id(story)
-  .w-full.lg:w-2/5.p-3.flex.flex-col.items-center.text-white.rounded-l-lg.relative class="px-2.5 #{story.complete? ? 'bg-blue-600' : 'bg-yellow-600' }"
-    = render 'stories/menu', story: story
+- if story.draft?
+  div id=dom_id(story)
+    = render 'stories/placeholder'
+- else
+  .flex.flex-col.lg:flex-row.justify-between.mb-6 class=('opacity-75' unless story.enabled?) class="lg:max-h-[30rem]" id=dom_id(story)
+    .w-full.lg:w-2/5.p-3.flex.flex-col.items-center.text-white.rounded-l-lg.relative class="px-2.5 #{story.complete? ? 'bg-blue-600' : 'bg-yellow-600' }"
+      = render 'stories/menu', story: story
 
-    header.flex.items-center.gap-2.mb-1
-      h2.text-lg.font-bold= story.title
+      header.flex.items-center.gap-2.mb-1
+        h2.text-lg.font-bold= story.title
 
-      span.text-sm
-        - if story.complete?
-          =< "(#{story.chapters.published.count}/#{story.chapters_count})"
-        - else
-          =< "(#{story.chapters.published.count}/X)"
+        span.text-sm
+          - if story.complete?
+            =< "(#{story.chapters.published.count}/#{story.chapters_count})"
+          - else
+            =< "(#{story.chapters.published.count}/X)"
 
-    .flex.items-center.gap-3.mb-3
-      p.inline-block.text-xs.font-medium.py-1.rounded class="px-2.5 #{story.complete? ? 'bg-orange-100 text-orange-800' : 'bg-purple-100 text-purple-800' }"
-        = story.human_mode
+      .flex.items-center.gap-3.mb-3
+        p.inline-block.text-xs.font-medium.py-1.rounded class="px-2.5 #{story.complete? ? 'bg-orange-100 text-orange-800' : 'bg-purple-100 text-purple-800' }"
+          = story.human_mode
 
-      p.inline-block.text-xs.font-medium.py-1.rounded.bg-gray-100.text-gray-800 class="px-2.5"
-        = story.human_language
+        p.inline-block.text-xs.font-medium.py-1.rounded.bg-gray-100.text-gray-800 class="px-2.5"
+          = story.human_language
 
-    .relative
-      div id=dom_id(story, 'cover')
-        = render 'stories/cover', story: story
+      .relative
+        div id=dom_id(story, 'cover')
+          = render 'stories/cover', story: story
 
-      .absolute.-bottom-4.-right-5
-        - if story.nostr_user.profile.picture
-          = image_tag story.nostr_user.profile.picture, class: 'w-20 mx-auto mb-1 rounded-full border-2'
+        .absolute.-bottom-4.-right-5
+          - if story.nostr_user.profile.picture
+            = image_tag story.nostr_user.profile.picture, class: 'w-20 mx-auto mb-1 rounded-full border-2'
 
-    span.text-sm= l(story.created_at)
+      span.text-sm= l(story.created_at)
 
-  .w-full.lg:w-3/5.p-3.bg-stone-700.rounded-r-lg.lg:overflow-y-auto
-    #chapters
-      = render story.chapters.with_attached_cover.order(id: :asc)
+    .w-full.lg:w-3/5.p-3.bg-stone-700.rounded-r-lg.lg:overflow-y-auto
+      #chapters
+        = render story.chapters.with_attached_cover.order(id: :asc)

--- a/config/locales/actverecord.fr.yml
+++ b/config/locales/actverecord.fr.yml
@@ -2,6 +2,9 @@ fr:
   activerecord:
     attributes:
       story:
+        mode: Mode
+        thematic: Thématique
+        nostr_user: Compte Nostr
         modes:
           complete: Aventure pré-générée
           dropper: Aventure au fur et à mesure

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -15,4 +15,6 @@ fr:
         enabled: Si coché, le compte Nostr sera autorisé à publier les aventures
 
       story:
-        nostr_user_id: Le compte Nostr de publication définit la langue de l'aventure
+        mode: Type d'aventure
+        thematic: Thème de l'aventure
+        nostr_user: Le compte Nostr de publication définit la langue de l'aventure

--- a/db/migrate/20230813070638_add_status_to_story.rb
+++ b/db/migrate/20230813070638_add_status_to_story.rb
@@ -1,0 +1,5 @@
+class AddStatusToStory < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stories, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_12_190559) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_13_070638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -108,6 +108,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_190559) do
     t.bigint "nostr_user_id"
     t.string "summary"
     t.string "back_cover_nostr_identifier"
+    t.integer "status", default: 0, null: false
     t.index ["back_cover_nostr_identifier"], name: "index_stories_on_back_cover_nostr_identifier", unique: true
     t.index ["nostr_identifier"], name: "index_stories_on_nostr_identifier", unique: true
     t.index ["nostr_user_id"], name: "index_stories_on_nostr_user_id"

--- a/lib/tasks/stories.rake
+++ b/lib/tasks/stories.rake
@@ -79,7 +79,13 @@ namespace :stories do
           end
         end
 
-        GenerateFullStoryJob.perform_now(bot, publish: true)
+        draft_story = Story.create! do |story|
+          story.mode = :complete
+          story.status = :draft
+          story.nostr_user = bot
+        end
+
+        GenerateFullStoryJob.perform_now(draft_story, publish: true)
       else
         raise StoryErrors::MissingCover unless @story.cover.attached?
 
@@ -163,7 +169,13 @@ namespace :stories do
         end
       end
 
-      GenerateFullStoryJob.perform_now(nostr_user, publish: :all)
+      draft_story = Story.create! do |story|
+        story.mode = :complete
+        story.status = :draft
+        story.nostr_user = nostr_user
+      end
+
+      GenerateFullStoryJob.perform_now(draft_story, publish: :all)
     end
   end
 end

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :story do
+    thematic
+    nostr_user
+  end
+end

--- a/spec/factories/thematics.rb
+++ b/spec/factories/thematics.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :thematic do
+    name_fr { Faker::Lorem.sentence }
+    name_en { Faker::Lorem.sentence }
+    description_fr { Faker::Lorem.paragraph }
+    description_en { Faker::Lorem.paragraph }
+    identifier { Faker::Lorem.word }
+  end
+end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Story do
+  describe '[validations rules]' do
+    subject { build_stubbed :story }
+
+    it { is_expected.to belong_to(:thematic) }
+    it { is_expected.to validate_presence_of(:mode) }
+    it { is_expected.to define_enum_for(:mode).with_values(described_class.modes.keys) }
+  end
+end


### PR DESCRIPTION
This big refactoring changes the way stories are created. Before the job was responsible to create the record in database and now, stories are saved from the controller as `draft` before being transmitted to the job.

Also update related design, i18n translations and flash notices from job.