### PR TITLE
Refactor stories job

### DIFF
--- a/.rubocop-disabled.yml
+++ b/.rubocop-disabled.yml
@@ -36,3 +36,6 @@ Style/FrozenStringLiteralComment:
 # Use smallcase prefixes for numeric literals.
 Style/NumericLiteralPrefix:
   Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false

--- a/app/exceptions/nostr_user_errors.rb
+++ b/app/exceptions/nostr_user_errors.rb
@@ -18,7 +18,7 @@ class NostrUserErrors < BaseErrors
   BotDisabled = Class.new(self) do
     attr_reader :nostr_user
 
-    def initialize(nostr_user:)
+    def initialize(nostr_user)
       super()
 
       @nostr_user = nostr_user
@@ -27,7 +27,7 @@ class NostrUserErrors < BaseErrors
     def message
       I18n.t(
         class_name,
-        name: nostr_user.name,
+        name: nostr_user.profile.identity,
         language: nostr_user.human_language,
         scope: i18n_scope
       )

--- a/app/exceptions/thematic_errors.rb
+++ b/app/exceptions/thematic_errors.rb
@@ -1,0 +1,15 @@
+class ThematicErrors < BaseErrors
+  ThematicDisabled = Class.new(self) do
+    attr_reader :thematic
+
+    def initialize(thematic)
+      super()
+
+      @thematic = thematic
+    end
+
+    def message
+      I18n.t(class_name, name: thematic.name, scope: i18n_scope)
+    end
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,7 +4,10 @@ class ApplicationJob < ActiveJob::Base
   private
 
   def broadcast_flash_alert(e)
-    message = "[#{e.class.name}] #{e.message}"
+    message = <<~MESSAGE
+      [#{e.class.name}]
+      #{e.message}
+    MESSAGE
 
     Rails.logger.tagged(e.class) do
       Rails.logger.error do

--- a/app/jobs/generate_dropper_story_job.rb
+++ b/app/jobs/generate_dropper_story_job.rb
@@ -4,12 +4,11 @@ class GenerateDropperStoryJob < GenerateStoryJob
     JSON::ParserError,
     ChapterErrors::EmptyPollOptions,
     ChapterErrors::MissingPollOptions
-  ]
+  ].freeze
 
-  # TODO: Validate that a nostr_user is enabled for a language or raise
-  # TODO: Validate that thematic is properly enabled or raise
   # @param draft_story [Story] draft story to generate
   def perform(draft_story)
+    validate!(draft_story)
     process!(draft_story, RETRYABLE_AI_ERRORS, publish: true)
   end
 end

--- a/app/jobs/generate_dropper_story_job.rb
+++ b/app/jobs/generate_dropper_story_job.rb
@@ -1,55 +1,15 @@
-class GenerateDropperStoryJob < ApplicationJob
+class GenerateDropperStoryJob < GenerateStoryJob
+  RETRYABLE_AI_ERRORS = [
+    Net::ReadTimeout,
+    JSON::ParserError,
+    ChapterErrors::EmptyPollOptions,
+    ChapterErrors::MissingPollOptions
+  ]
+
   # TODO: Validate that a nostr_user is enabled for a language or raise
   # TODO: Validate that thematic is properly enabled or raise
   # @param draft_story [Story] draft story to generate
   def perform(draft_story)
-    nostr_user = draft_story.nostr_user
-
-    flash_message = <<~CONTENT
-      - Mode: <strong>#{draft_story.human_mode}</strong>
-      - Thèmatique: <strong>#{draft_story.thematic_name}</strong>
-      - Compte Nostr: <strong>#{nostr_user.profile.identity}</strong>
-      - Langue: <strong>#{nostr_user.human_language}</strong>
-    CONTENT
-
-    Story.broadcast_flash(:notice, flash_message)
-
-    prompt = I18n.t('begin_adventure', description: draft_story.thematic_description)
-
-    Retry.on(
-      Net::ReadTimeout,
-      JSON::ParserError,
-      ChapterErrors::EmptyPollOptions,
-      ChapterErrors::MissingPollOptions
-    ) do
-      @json = ChatgptDropperService.call(prompt, nostr_user.language)
-    end
-
-    Story.broadcast_flash(:notice, <<~CONTENT)
-      L'aventure <strong>#{@json['story_title']}</strong> vient d'être générée.
-    CONTENT
-
-    ApplicationRecord.transaction do
-      story_accurate_cover_prompt = ChatgptSummaryService.call("#{@json['story_title']}, #{draft_story.thematic_description}")
-
-      draft_story.update!(
-        title: @json['story_title'],
-        raw_response_body: @json,
-        summary: story_accurate_cover_prompt
-      )
-
-      chapter_accurate_cover_prompt = ChatgptSummaryService.call(@json['content'])
-
-      draft_story.chapters.create!(
-        title: @json['title'],
-        content: @json['content'],
-        prompt: prompt,
-        summary: chapter_accurate_cover_prompt,
-        chat_raw_response_body: @json,
-        publish: true
-      )
-
-      draft_story.completed!
-    end
+    process!(draft_story, RETRYABLE_AI_ERRORS, publish: true)
   end
 end

--- a/app/jobs/generate_full_story_job.rb
+++ b/app/jobs/generate_full_story_job.rb
@@ -1,58 +1,15 @@
-class GenerateFullStoryJob < ApplicationJob
+class GenerateFullStoryJob < GenerateStoryJob
+  RETRYABLE_AI_ERRORS = [
+    Net::ReadTimeout,
+    JSON::ParserError,
+    ChapterErrors::FullStoryMissingChapters
+  ]
+
   # TODO: Validate that a nostr_user is enabled for a language or raise
   # TODO: Validate that thematic is properly enabled or raise
   # @param draft_story [Story] draft story to generate
   # @param publish [Boolean] Should the {Chapter} be published ?
   def perform(draft_story, publish: false)
-    nostr_user = draft_story.nostr_user
-
-    flash_message = <<~CONTENT
-      - Mode: <strong>#{draft_story.human_mode}</strong>
-      - Thèmatique: <strong>#{draft_story.thematic_name}</strong>
-      - Compte Nostr: <strong>#{nostr_user.profile.identity}</strong>
-      - Langue: <strong>#{nostr_user.human_language}</strong>
-    CONTENT
-
-    Story.broadcast_flash(:notice, flash_message)
-
-    prompt = I18n.t('begin_adventure', description: draft_story.thematic_description)
-
-    Retry.on(
-      Net::ReadTimeout,
-      JSON::ParserError,
-      ChapterErrors::FullStoryMissingChapters
-    ) do
-      @json = ChatgptCompleteService.call(prompt, nostr_user.language)
-
-      raise ChapterErrors::FullStoryMissingChapters if @json['chapters'].count < 3
-    end
-
-    Story.broadcast_flash(:notice, <<~CONTENT)
-      L'aventure <strong>#{@json['title']}</strong> vient d'être générée avec <strong>#{@json['chapters'].count} chapitres</strong>.
-    CONTENT
-
-    ApplicationRecord.transaction do
-      story_accurate_cover_prompt = ChatgptSummaryService.call("#{@json['title']}, #{draft_story.thematic_description}")
-
-      draft_story.update!(
-        title: @json['title'],
-        raw_response_body: @json,
-        summary: story_accurate_cover_prompt
-      )
-
-      @json['chapters'].each_with_index do |row, index|
-        chapter_accurate_cover_prompt = ChatgptSummaryService.call(row['content'])
-
-        draft_story.chapters.create!(
-          title: row['title'],
-          content: row['content'],
-          summary: chapter_accurate_cover_prompt,
-          chat_raw_response_body: row,
-          publish: publish == :all || (publish && index.zero?)
-        )
-      end
-
-      draft_story.completed!
-    end
+    process!(draft_story, RETRYABLE_AI_ERRORS, publish: publish)
   end
 end

--- a/app/jobs/generate_full_story_job.rb
+++ b/app/jobs/generate_full_story_job.rb
@@ -3,13 +3,12 @@ class GenerateFullStoryJob < GenerateStoryJob
     Net::ReadTimeout,
     JSON::ParserError,
     ChapterErrors::FullStoryMissingChapters
-  ]
+  ].freeze
 
-  # TODO: Validate that a nostr_user is enabled for a language or raise
-  # TODO: Validate that thematic is properly enabled or raise
   # @param draft_story [Story] draft story to generate
   # @param publish [Boolean] Should the {Chapter} be published ?
   def perform(draft_story, publish: false)
+    validate!(draft_story)
     process!(draft_story, RETRYABLE_AI_ERRORS, publish: publish)
   end
 end

--- a/app/jobs/generate_story_job.rb
+++ b/app/jobs/generate_story_job.rb
@@ -1,0 +1,78 @@
+class GenerateStoryJob < ApplicationJob
+  private
+
+  def process!(draft_story, retryable_ai_errors, publish: false)
+    nostr_user = draft_story.nostr_user
+
+    flash_message = <<~MESSAGE
+      - Mode: <strong>#{draft_story.human_mode}</strong>
+      - Thèmatique: <strong>#{draft_story.thematic_name}</strong>
+      - Compte Nostr: <strong>#{nostr_user.profile.identity}</strong>
+      - Langue: <strong>#{nostr_user.human_language}</strong>
+    MESSAGE
+
+    Story.broadcast_flash(:notice, flash_message)
+
+    prompt = I18n.t('begin_adventure', description: draft_story.thematic_description)
+
+    Retry.on(retryable_ai_errors) do
+      if draft_story.complete?
+        @json = ChatgptCompleteService.call(prompt, nostr_user.language)
+
+        raise ChapterErrors::FullStoryMissingChapters if @json['chapters'].count < 3
+      else
+        @json = ChatgptDropperService.call(prompt, nostr_user.language)
+      end
+    end
+
+     if draft_story.complete?
+      story_title = @json['title']
+
+      flash_message = <<~MESSAGE
+        L'aventure <strong>#{story_title}</strong> vient d'être générée avec <strong>#{@json['chapters'].count} chapitres</strong>.
+      MESSAGE
+    else
+      story_title = @json['story_title']
+
+      flash_message = <<~MESSAGE
+        L'aventure <strong>#{story_title}</strong> vient d'être générée.
+      MESSAGE
+    end
+
+    Story.broadcast_flash(:notice, flash_message)
+
+    ApplicationRecord.transaction do
+      story_accurate_cover_prompt = ChatgptSummaryService.call("#{story_title}, #{draft_story.thematic_description}")
+
+      draft_story.update!(
+        title: story_title,
+        raw_response_body: @json,
+        summary: story_accurate_cover_prompt
+      )
+
+      if draft_story.dropper?
+        @json['chapters'] = [@json.except(:story_title)]
+      end
+
+      @json['chapters'].each_with_index do |row, index|
+        chapter_accurate_cover_prompt = ChatgptSummaryService.call(row['content'])
+
+        publish_value = if draft_story.complete?
+          publish == :all || (publish && index.zero?)
+        else
+          publish
+        end
+
+        draft_story.chapters.create!(
+          title: row['title'],
+          content: row['content'],
+          summary: chapter_accurate_cover_prompt,
+          chat_raw_response_body: row,
+          publish: publish_value
+        )
+      end
+
+      draft_story.completed!
+    end
+  end
+end

--- a/config/locales/cover_errors.en.yml
+++ b/config/locales/cover_errors.en.yml
@@ -1,4 +1,6 @@
 en:
   exceptions:
     cover_errors:
-      nsfw_detected: "NSFW cover detected, please generate it again [used prompt: %{prompt}]"
+      nsfw_detected: |-
+        NSFW cover detected, please generate it again.
+        Used prompt: %{prompt}

--- a/config/locales/cover_errors.fr.yml
+++ b/config/locales/cover_errors.fr.yml
@@ -1,4 +1,6 @@
 fr:
   exceptions:
     cover_errors:
-      nsfw_detected: "La couverture est NSFW, veuillez la générer à nouveau [prompt utilisé: %{prompt}]"
+      nsfw_detected: |-
+        La couverture est NSFW, veuillez la générer à nouveau.
+        Prompt utilisé: %{prompt}

--- a/config/locales/thematic_errors.en.yml
+++ b/config/locales/thematic_errors.en.yml
@@ -1,0 +1,4 @@
+en:
+  exceptions:
+    thematic_errors:
+      thematic_disabled: "The \"%{name}\" thematic is deactivated: you can't publish a new story or chapter until it's reactivated"

--- a/config/locales/thematic_errors.fr.yml
+++ b/config/locales/thematic_errors.fr.yml
@@ -1,0 +1,4 @@
+fr:
+  exceptions:
+    thematic_errors:
+      thematic_disabled: "La thématique \"%{name}\" est désactivée, vous ne pouvez pas publier de nouvelle histoire ou chapitre tant qu'elle ne sera pas réactivée"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,4 @@
 :queues:
   - default
   - nostr
+  - artificial_intelligence

--- a/lib/tasks/stories.rake
+++ b/lib/tasks/stories.rake
@@ -23,7 +23,7 @@ namespace :stories do
 
         []
       elsif !nostr_user.enabled?
-        e = NostrUserErrors::BotDisabled.new(nostr_user: nostr_user)
+        e = NostrUserErrors::BotDisabled.new(nostr_user)
 
         Rails.logger.tagged(e.class) do
           Rails.logger.info do
@@ -52,7 +52,7 @@ namespace :stories do
 
           []
         elsif !nostr_user.enabled?
-          e = NostrUserErrors::BotDisabled.new(nostr_user: nostr_user)
+          e = NostrUserErrors::BotDisabled.new(nostr_user)
 
           Rails.logger.tagged(e.class) do
             Rails.logger.info do
@@ -155,7 +155,7 @@ namespace :stories do
         end
       end
     elsif !nostr_user.enabled?
-      e = NostrUserErrors::BotDisabled.new(nostr_user: nostr_user)
+      e = NostrUserErrors::BotDisabled.new(nostr_user)
 
       Rails.logger.tagged(e.class) do
         Rails.logger.info do


### PR DESCRIPTION
Both job `GenerateFullStoryJob` and `GenerateDropperStoryJob` have very similar content.
To DRY them, a new parent job will handle the code.Both job `GenerateFullStoryJob` and `GenerateDropperStoryJob` have very similar content.
To DRY them, a new parent job will handle the code.