### PR TITLE
Add publication rules

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -66,7 +66,8 @@ class StoriesController < ApplicationController
   end
 
   def story_params
-    params.require(:story).permit(:nostr_user_id, :mode, :thematic_id)
+    params.require(:story)
+          .permit(:nostr_user_id, :mode, :thematic_id, :publication_rule)
   end
 
   def mode

--- a/app/jobs/generate_dropper_story_job.rb
+++ b/app/jobs/generate_dropper_story_job.rb
@@ -9,6 +9,6 @@ class GenerateDropperStoryJob < GenerateStoryJob
   # @param draft_story [Story] draft story to generate
   def perform(draft_story)
     validate!(draft_story)
-    process!(draft_story, RETRYABLE_AI_ERRORS, publish: true)
+    process!(draft_story, RETRYABLE_AI_ERRORS)
   end
 end

--- a/app/jobs/generate_full_story_job.rb
+++ b/app/jobs/generate_full_story_job.rb
@@ -7,8 +7,8 @@ class GenerateFullStoryJob < GenerateStoryJob
 
   # @param draft_story [Story] draft story to generate
   # @param publish [Boolean] Should the {Chapter} be published ?
-  def perform(draft_story, publish: false)
+  def perform(draft_story)
     validate!(draft_story)
-    process!(draft_story, RETRYABLE_AI_ERRORS, publish: publish)
+    process!(draft_story, RETRYABLE_AI_ERRORS)
   end
 end

--- a/app/jobs/nostr_jobs/all_publisher_job.rb
+++ b/app/jobs/nostr_jobs/all_publisher_job.rb
@@ -11,6 +11,7 @@ module NostrJobs
 
       story.chapters.not_published.by_position.each do |chapter|
         NostrPublisherService.call(chapter)
+        sleep 1
       end
     end
   end

--- a/app/views/application/_quick_custom_story_generator.html.slim
+++ b/app/views/application/_quick_custom_story_generator.html.slim
@@ -1,10 +1,10 @@
 = simple_form_for Story.new,
                   url: stories_path,
                   html: { \
-                    class: 'flex flex-col lg:flex-row items-center gap-3 justify-between p-4 bg-gray-200 rounded-b-lg' \
+                    class: 'flex flex-col items-center gap-6 justify-between p-4 bg-gray-200 rounded-b-lg' \
                   } do |f|
 
-  .flex.flex-col.lg:flex-row.items-start.gap-3.justify-between
+  .flex.flex-col.lg:flex-row.gap-3.justify-between
     = f.association :thematic,
                     collection: Thematic.enabled,
                     include_blank: '[Aléatoire]',
@@ -26,5 +26,12 @@
                     input_html: { class: 'w-full' },
                     wrapper_html: { class: 'text-center w-full' }
 
+    = f.input :publication_rule,
+              collection: select_options_for(Story, :publication_rules),
+              include_blank: false,
+              label_html: { class: 'block italic mb-2' },
+              input_html: { class: 'w-full' },
+              wrapper_html: { class: 'text-center w-full' }
+
   = f.button :submit, 'Créer une aventure sur mesure',
-             class: 'bg-green-600 p-2 rounded-lg text-white cursor-pointer'
+             class: 'bg-green-600 p-2 rounded-lg text-white cursor-pointer hover:bg-green-500 transition-colors'

--- a/app/views/stories/_placeholder.html.slim
+++ b/app/views/stories/_placeholder.html.slim
@@ -1,9 +1,9 @@
 .bg-stone-700.p-3.rounded-lg.space-y-8.animate-pulse.md:space-y-0.md:space-x-8.md:flex.md:items-center.mb-6 role="status"
-  .flex.w-1/3.items-center.justify-center.w-full.h-72.bg-gray-300.rounded
+  .flex.w-1/3.items-center.justify-center.h-72.bg-gray-300.rounded
     svg.w-10.h-10.text-gray-200 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18"
       path d="M18 0H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2Zm-5.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3Zm4.376 10.481A1 1 0 0 1 16 15H4a1 1 0 0 1-.895-1.447l3.5-7A1 1 0 0 1 7.468 6a.965.965 0 0 1 .9.5l2.775 4.757 1.546-1.887a1 1 0 0 1 1.618.1l2.541 4a1 1 0 0 1 .028 1.011Z"
 
-  .w-full
+  .w-2/3
     div class="h-2.5 bg-gray-200 rounded-full w-48 mb-4"
     div class="h-2 bg-gray-200 rounded-full max-w-[480px] mb-2.5"
     div class="h-2 bg-gray-200 rounded-full mb-2.5"

--- a/config/locales/actverecord.en.yml
+++ b/config/locales/actverecord.en.yml
@@ -2,3 +2,7 @@ en:
   activerecord:
     attributes:
       story:
+        publication_rules:
+          do_not_publish: Do not publish
+          publish_first_chapter: Publish first chapter
+          publish_all_chapters: Publish all chapters

--- a/config/locales/actverecord.fr.yml
+++ b/config/locales/actverecord.fr.yml
@@ -8,6 +8,10 @@ fr:
         modes:
           complete: Aventure pré-générée
           dropper: Aventure au fur et à mesure
+        publication_rules:
+          do_not_publish: Ne pas publier
+          publish_first_chapter: Publier le premier chapitre
+          publish_all_chapters: Publier tous les chapitres
 
       relay:
         url: WebSocket URL (ws:// ou wss://)

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -8,6 +8,11 @@ fr:
     error_notification:
       default_message: "Veuillez vérifier les problèmes suivants:"
 
+    labels:
+      story:
+        publication_rule: Règles de publication
+        nostr_user_id: Compte Nostr
+
     hints:
       nostr_user:
         private_key: La clé privée est chiffrée en base de données

--- a/db/migrate/20230812195308_add_publication_rule_to_story.rb
+++ b/db/migrate/20230812195308_add_publication_rule_to_story.rb
@@ -1,0 +1,5 @@
+class AddPublicationRuleToStory < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stories, :publication_rule, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,6 +109,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_070638) do
     t.string "summary"
     t.string "back_cover_nostr_identifier"
     t.integer "status", default: 0, null: false
+    t.integer "publication_rule", default: 0, null: false
     t.index ["back_cover_nostr_identifier"], name: "index_stories_on_back_cover_nostr_identifier", unique: true
     t.index ["nostr_identifier"], name: "index_stories_on_nostr_identifier", unique: true
     t.index ["nostr_user_id"], name: "index_stories_on_nostr_user_id"

--- a/lib/tasks/stories.rake
+++ b/lib/tasks/stories.rake
@@ -82,10 +82,11 @@ namespace :stories do
         draft_story = Story.create! do |story|
           story.mode = :complete
           story.status = :draft
+          story.publication_rule = :publish_first_chapter
           story.nostr_user = bot
         end
 
-        GenerateFullStoryJob.perform_now(draft_story, publish: true)
+        GenerateFullStoryJob.perform_now(draft_story)
       else
         raise StoryErrors::MissingCover unless @story.cover.attached?
 
@@ -172,10 +173,11 @@ namespace :stories do
       draft_story = Story.create! do |story|
         story.mode = :complete
         story.status = :draft
+        story.publication_rule = :publish_all_chapters
         story.nostr_user = nostr_user
       end
 
-      GenerateFullStoryJob.perform_now(draft_story, publish: :all)
+      GenerateFullStoryJob.perform_now(draft_story)
     end
   end
 end

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :story do
+    traits_for_enum :mode
+    traits_for_enum :publication_rule
+
     thematic
     nostr_user
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -7,5 +7,67 @@ RSpec.describe Story do
     it { is_expected.to belong_to(:thematic) }
     it { is_expected.to validate_presence_of(:mode) }
     it { is_expected.to define_enum_for(:mode).with_values(described_class.modes.keys) }
+    it { is_expected.to define_enum_for(:publication_rule).with_values(described_class.publication_rules.keys) }
+  end
+
+  describe '#publish_me?' do
+    subject { story.publish_me?(index) }
+
+    let(:story) { create :story, mode, publication_rule }
+    let(:index) { 0 }
+
+    context 'when story is dropper' do
+      let(:mode) { :dropper }
+
+      context 'when not publishing' do
+        let(:publication_rule) { :do_not_publish }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when publish first' do
+        let(:publication_rule) { :publish_first_chapter }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when publish all' do
+        let(:publication_rule) { :publish_all_chapters }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when story is complete' do
+      let(:mode) { :complete }
+
+      context 'when not publishing' do
+        let(:publication_rule) { :do_not_publish }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when publish first' do
+        let(:publication_rule) { :publish_first_chapter }
+
+        context 'when index is 0' do
+          let(:index) { 0 }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when index is not 0' do
+          let(:index) { 1 }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when publish all' do
+        let(:publication_rule) { :publish_all_chapters }
+
+        it { is_expected.to be true }
+      end
+    end
   end
 end


### PR DESCRIPTION
Add a new enum to save at the `Story` model level the publication rule for a story after generating.

Three options are possible:
- do not publish
- publish first chapter
- publish all chapters (only for `complete` stories mode)

Update the quick generation form from frontend to reflect this attribute and Add related specs.


<img width="1263" alt="Capture d’écran 2023-08-13 à 21 29 53" src="https://github.com/La-Voix-du-chat-artiste/fabelia/assets/5428510/56c9ff04-0e4d-424d-b817-ca0fd3be522c">
