### PR TITLE
Update flash rendering and flash disappear

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -26,7 +26,7 @@
   z-index: 21;
 }
 
-#flashes .flash__message {
+.appear-then-fade {
   animation: appear-then-fade 10s both;
 }
 
@@ -36,6 +36,19 @@
   }
   5%, 60% {
     opacity: 1
+  }
+}
+
+.fade-out {
+  animation: fade-out 1s both;
+}
+
+@keyframes fade-out {
+  0% {
+    opacity: 1
+  }
+  100% {
+    opacity: 0
   }
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   rescue_from ActionPolicy::Unauthorized, with: :unauthorized_access
   rescue_from StoryErrors, with: :redirect_to_root
 
+  add_flash_types :warning, :info
+
   private
 
   def not_authenticated

--- a/app/javascript/controllers/removals_controller.js
+++ b/app/javascript/controllers/removals_controller.js
@@ -1,7 +1,20 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
+  static values = {
+    disappear: { type: Boolean, default: true }
+  }
+
   remove() {
-    this.element.remove()
+    if (this.disappearValue) {
+      this.element.remove()
+    }
+  }
+
+  forceRemove(e) {
+    e.preventDefault()
+
+    this.disappearValue = true
+    this.element.classList.add('fade-out')
   }
 }

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -19,7 +19,7 @@ class ApplicationJob < ActiveJob::Base
       end
     end
 
-    ApplicationRecord.broadcast_flash(:alert, message)
+    ApplicationRecord.broadcast_flash(:alert, message, disappear: false)
   end
 
   def broadcast_flash_notice(message)

--- a/app/jobs/generate_story_job.rb
+++ b/app/jobs/generate_story_job.rb
@@ -16,18 +16,18 @@ class GenerateStoryJob < ApplicationJob
     raise ThematicErrors::ThematicDisabled.new(draft_story.thematic) unless draft_story.thematic.enabled?
   end
 
-  def process!(draft_story, retryable_ai_errors)
+  def process!(draft_story, retryable_ai_errors = [])
     nostr_user = draft_story.nostr_user
 
     flash_message = <<~MESSAGE
-      - Mode: <strong>#{draft_story.human_mode}</strong>
-      - Thèmatique: <strong>#{draft_story.thematic_name}</strong>
-      - Compte Nostr: <strong>#{nostr_user.profile.identity}</strong>
-      - Langue: <strong>#{nostr_user.human_language}</strong>
-      - Stratégie de publication: <strong>#{draft_story.human_publication_rule}</strong>
+      • Mode: <strong>#{draft_story.human_mode}</strong>
+      • Thématique: <strong>#{draft_story.thematic_name}</strong>
+      • Compte Nostr: <strong>#{nostr_user.profile.identity}</strong>
+      • Langue: <strong>#{nostr_user.human_language}</strong>
+      • Stratégie de publication: <strong>#{draft_story.human_publication_rule}</strong>
     MESSAGE
 
-    Story.broadcast_flash(:notice, flash_message)
+    Story.broadcast_flash(:info, flash_message, disappear: false)
 
     prompt = I18n.t('begin_adventure', description: draft_story.thematic_description)
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,14 +5,15 @@ class ApplicationRecord < ActiveRecord::Base
     I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}", locale: locale)
   end
 
-  def self.broadcast_flash(type, message)
+  def self.broadcast_flash(type, message, disappear: true)
     Turbo::StreamsChannel.broadcast_prepend_to(
       :flashes,
       target: 'flashes',
       partial: 'flash',
       locals: {
         flash_type: type.to_s,
-        message: message
+        message: message,
+        disappear: disappear
       }
     )
   end

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,2 +1,27 @@
-.flash__message.p-4.mb-4.text-sm.rounded-xl.overflow-y-auto class="#{flash_type == 'notice' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'}" data-controller="removals" data-action="animationend->removals#remove"
-  = simple_format message
+- if flash_type == 'notice'
+  - flash_classes = 'text-green-500 bg-green-50 border-green-800'
+  - close_button_classes = 'text-green-500 focus:ring-green-400 bg-green-100 hover:bg-green-200'
+- elsif flash_type == 'info'
+  - flash_classes = 'text-blue-500 bg-blue-50 border-blue-800'
+  - close_button_classes = 'text-blue-500 focus:ring-blue-400 bg-blue-100 hover:bg-blue-200'
+- elsif flash_type == 'warning'
+  - flash_classes = 'text-orange-500 bg-orange-50 border-orange-800'
+  - close_button_classes = 'text-orange-500 focus:ring-orange-400 bg-orange-100 hover:bg-orange-200'
+- else
+  - flash_classes = 'text-red-500 bg-red-50 border-red-800'
+  - close_button_classes = 'text-red-500 focus:ring-red-400 bg-red-100 hover:bg-red-200'
+
+.flex.p-4.mb-4.text-sm.border.rounded-lg role="alert" data-controller="removals" data-action="animationend->removals#remove" class=flash_classes class=('appear-then-fade' if disappear)
+  <svg class="flex-shrink-0 inline w-4 h-4 mr-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+    <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+  </svg>
+
+  div.mr-3
+    p.text-xs.italic.mb-1.underline= l(Time.current)
+    = simple_format message
+
+  - unless disappear
+    button type="button" class="ml-auto -mx-1.5 -my-1.5 rounded-lg focus:ring-2 inline-flex items-center justify-center h-8 w-8 transition-colors" aria-label="Close" class=close_button_classes data-action="click->removals#forceRemove"
+      <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+      </svg>

--- a/app/views/application/_flashes.html.slim
+++ b/app/views/application/_flashes.html.slim
@@ -1,2 +1,2 @@
 - flash.each do |flash_type, message|
-  = render 'flash', flash_type: flash_type, message: message
+  = render 'flash', flash_type: flash_type, message: message, disappear: true

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,7 +1,7 @@
 fr:
   time:
     formats:
-      default: "%d/%m/%Y %Hh%M"
+      default: "%d/%m/%Y à %Hh%M"
       long: "%A %d %B %Y %Hh%M"
       short: "%d %b %Hh%M"
       hour: "%Hh%M"


### PR DESCRIPTION
Introduce a new option to let user remove manually the flash instead of making it disappear automatically after a delay.

Update the style for a more friendly flash look.

<img width="273" alt="Capture d’écran 2023-08-14 à 08 31 28" src="https://github.com/La-Voix-du-chat-artiste/fabelia/assets/5428510/29b46f13-1730-4e0e-9240-9ddd3f30ea3a">
