### PR TITLE
Update turbo confirm style

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,17 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+// @see https://gorails.com/episodes/custom-hotwire-turbo-confirm-modals
+Turbo.setConfirmMethod((message, element) => {
+  let dialog = document.getElementById('turbo-confirm')
+
+  dialog.querySelector('p').textContent = message
+  dialog.showModal()
+
+  return new Promise((resolve, reject) => {
+    dialog.addEventListener('close', () => {
+      resolve(dialog.returnValue == 'confirm')
+    }, { once: true })
+  })
+})

--- a/app/views/application/_turbo_confirm.html.slim
+++ b/app/views/application/_turbo_confirm.html.slim
@@ -1,0 +1,20 @@
+dialog#turbo-confirm.relative.bg-white.rounded-lg.shadow
+  form#popup-modal.relative.w-full.max-w-md.max-h-full method="dialog" tabindex="-1"
+    button value="cancel" class="absolute top-3 right-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center"
+      <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+      </svg>
+      span.sr-only Fermer la modale
+
+    .p-6.text-center
+      <svg class="mx-auto mb-4 text-gray-400 w-12 h-12" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 11V6m0 8h.01M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+      </svg>
+
+      p.mb-5.text-lg.font-normal.text-gray-500 Êtes-vous sûr ?
+
+      button value="cancel" class="text-gray-500 bg-white hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-200 rounded-lg border border-gray-200 text-sm font-medium px-5 py-2.5 hover:text-gray-900 focus:z-10 mr-2"
+        | Annuler
+
+      button value="confirm" class="text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center"
+        | Confirmer

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,3 +18,5 @@ html
       #flashes= render 'flashes'
 
       = yield
+
+      = render 'turbo_confirm'


### PR DESCRIPTION
Refactoring the browser confirm modal following the great tutorial from [gorails](https://gorails.com/episodes/custom-hotwire-turbo-confirm-modals).

Design use Tailwind CSS style.

<img width="481" alt="Capture d’écran 2023-08-14 à 11 04 06" src="https://github.com/La-Voix-du-chat-artiste/fabelia/assets/5428510/35ce6fd4-8357-4b0f-8aa5-ab1004344cc2">
