### PR TITLE
Introduce `Setting` scaffold

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'slim-rails'
 gem 'sorcery'
 gem 'sprockets-rails'
 gem 'stimulus-rails'
+gem 'store_model'
 gem 'tailwindcss-rails'
 gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,6 +362,8 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
+    store_model (2.1.0)
+      activerecord (>= 5.2)
     tailwindcss-rails (2.0.30-x86_64-darwin)
       railties (>= 6.0.0)
     temple (0.10.2)
@@ -440,6 +442,7 @@ DEPENDENCIES
   sorcery
   sprockets-rails
   stimulus-rails
+  store_model
   tailwindcss-rails
   turbo-rails
   tzinfo-data

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,37 @@
+class SettingsController < ApplicationController
+  before_action :set_setting, only: %i[show edit update]
+
+  # @route GET /settings (settings)
+  def show
+    authorize! @setting
+  end
+
+  # @route GET /settings/edit (edit_settings)
+  def edit
+    authorize! @setting
+  end
+
+  # @route PATCH /settings (settings)
+  # @route PUT /settings (settings)
+  def update
+    authorize! @setting
+
+    respond_to do |format|
+      if @setting.update(setting_params)
+        format.html { redirect_to settings_path, notice: 'Setting was successfully updated.' }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+  def set_setting
+    @setting = Setting.first
+  end
+
+  def setting_params
+    params.require(:setting).permit(:chapter_options)
+  end
+end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/jumpto_controller.js
+++ b/app/javascript/controllers/jumpto_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = {
+    divId: String
+  }
+
+  jump(e) {
+    e.preventDefault()
+
+    const $jumpTo = document.getElementById(this.divIdValue)
+
+    if (!$jumpTo) {
+      return
+    }
+
+    window.scroll({
+      behavior: 'smooth',
+      left: 0,
+      top: $jumpTo.offsetTop - 30
+    })
+  }
+}

--- a/app/javascript/controllers/settings_controller.js
+++ b/app/javascript/controllers/settings_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    chapterOptions: Object
+  }
+
+  connect() {
+    this.element.style.height = `${this.element.scrollHeight}px`
+    this.element.value = JSON.stringify(this.chapterOptionsValue, undefined, 2)
+  }
+}

--- a/app/jobs/generate_story_job.rb
+++ b/app/jobs/generate_story_job.rb
@@ -31,7 +31,7 @@ class GenerateStoryJob < ApplicationJob
 
     prompt = I18n.t('begin_adventure', description: draft_story.thematic_description)
 
-    Retry.on(retryable_ai_errors) do
+    Retry.on(*retryable_ai_errors) do
       if draft_story.complete?
         @json = ChatgptCompleteService.call(prompt, nostr_user.language)
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,6 +5,7 @@ class ApplicationRecord < ActiveRecord::Base
     I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}", locale: locale)
   end
 
+  # :nocov:
   def self.broadcast_flash(type, message, disappear: true)
     Turbo::StreamsChannel.broadcast_prepend_to(
       :flashes,
@@ -17,4 +18,5 @@ class ApplicationRecord < ActiveRecord::Base
       }
     )
   end
+  # :nocov:
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,23 @@
+class Setting < ApplicationRecord
+  attribute :chapter_options, ChapterOption.to_type
+
+  validates :chapter_options, store_model: { merge_errors: true }
+
+  before_create :confirm_singularity
+
+  private
+
+  def confirm_singularity
+    raise StandardError.new('There can be only one.') if Setting.exists?
+  end
+end
+
+# == Schema Information
+#
+# Table name: settings
+#
+#  id              :bigint(8)        not null, primary key
+#  chapter_options :jsonb            not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#

--- a/app/models/setting/chapter_option.rb
+++ b/app/models/setting/chapter_option.rb
@@ -1,0 +1,47 @@
+class Setting
+  class ChapterOption
+    include StoreModel::Model
+
+    MINIMUM_CHAPTERS_COUNT = 4
+    MAXIMUM_CHAPTERS_COUNT = 10
+    STABLE_DIFFUSION_PROMPT = 'Very very beautiful, elegant, highly detailed, realistic, depth'.freeze
+    CHATGPT_FULL_STORY_SYSTEM_PROMPT = <<~PROMPT.strip.freeze
+      You act as a story book adventure narrator. The adventure should be epic with elaborated scenario and plot twist. Make chapter from around ten paragraphs each, only in {{language}} language. For each chapter, choose a list of two options and then choose randomly one to be the prompt of the next chapter. Ensure returned chapters array contains between {{minimum_chapters_count}} and {{maximum_chapters_count}} only. Ensure the story is complete and have a real coherent ending.
+
+      Provide a RFC 8259 compliant JSON response following this format without deviation:
+    PROMPT
+
+    CHATGPT_DROPPER_STORY_SYSTEM_PROMPT = <<~PROMPT.strip.freeze
+      You act as a story book adventure narrator. The adventure should be progressive, generated one chapter at a time with a set of proposed options to continue the adventure. You reply in {{language}} only. Use "adventure_ended" boolean to inform that the story is considered as completed when the adventure before chapter {{maximum_chapters_count}}. Ensure the story has a real coherent ending.
+    PROMPT
+
+    attribute :minimum_chapters_count, :integer,
+              default: MINIMUM_CHAPTERS_COUNT
+    attribute :maximum_chapters_count, :integer,
+              default: MAXIMUM_CHAPTERS_COUNT
+    attribute :chatgpt_full_story_system_prompt, :string,
+              default: CHATGPT_FULL_STORY_SYSTEM_PROMPT
+    attribute :chatgpt_dropper_story_system_prompt, :string,
+              default: CHATGPT_DROPPER_STORY_SYSTEM_PROMPT
+    attribute :stable_diffusion_prompt, :string,
+              default: STABLE_DIFFUSION_PROMPT
+
+    validates :minimum_chapters_count,
+              presence: true,
+              numericality: {
+                greater_than_or_equal_to: MINIMUM_CHAPTERS_COUNT,
+                less_than_or_equal_to: :maximum_chapters_count
+              }
+
+    validates :maximum_chapters_count,
+              presence: true,
+              numericality: {
+                less_than_or_equal_to: MAXIMUM_CHAPTERS_COUNT,
+                greater_than_or_equal_to: :minimum_chapters_count
+              }
+
+    validates :stable_diffusion_prompt, presence: true
+    validates :chatgpt_full_story_system_prompt, presence: true
+    validates :chatgpt_dropper_story_system_prompt, presence: true
+  end
+end

--- a/app/policies/setting_policy.rb
+++ b/app/policies/setting_policy.rb
@@ -1,0 +1,13 @@
+class SettingPolicy < ApplicationPolicy
+  def show?
+    true
+  end
+
+  def edit?
+    update?
+  end
+
+  def update?
+    true
+  end
+end

--- a/app/services/base_replicate.rb
+++ b/app/services/base_replicate.rb
@@ -16,6 +16,6 @@ class BaseReplicate < ApplicationService
   end
 
   def default_keywords
-    '. Very very beautiful, elegant, highly detailed, realistic, depth'
+    Setting.first.chapter_options.stable_diffusion_prompt
   end
 end

--- a/app/services/chatgpt_complete_service.rb
+++ b/app/services/chatgpt_complete_service.rb
@@ -28,14 +28,8 @@ class ChatgptCompleteService < ChatgptService
     array
   end
 
-  def system_prompt
-    <<~STRING.strip
-      You act as a story book adventure narrator. The adventure should be epic with elaborated scenario and plot twist. Make chapter from around ten paragraphs each, only in #{language_name} language. For each chapter, choose a list of two options and then choose randomly one to be the prompt of the next chapter.
-
-      Provide a RFC 8259 compliant JSON response following this format without deviation:
-
-      #{json_format.to_json}
-    STRING
+  def system_prompt_for_mode
+    chapter_options.chatgpt_full_story_system_prompt
   end
 
   def json_format
@@ -68,9 +62,5 @@ class ChatgptCompleteService < ChatgptService
 
   def reminder
     'Ensure the story is complete and have a real coherent ending. Also reply in JSON RFC 8259 compliant format as instructed'
-  end
-
-  def language_name
-    I18nData.languages(:en)[language]
   end
 end

--- a/app/services/chatgpt_dropper_service.rb
+++ b/app/services/chatgpt_dropper_service.rb
@@ -41,14 +41,8 @@ class ChatgptDropperService < ChatgptService
     array
   end
 
-  def system_prompt
-    <<~STRING.strip
-      You act as a story book adventure narrator. The adventure should be progressive, generated one chapter at a time with a set of proposed options to continue the adventure. You reply in #{language_name} only. Use "adventure_ended" boolean to inform that the story is considered as completed.
-
-      Provide a RFC 8259 compliant JSON response following this format without deviation:
-
-      #{json_format.to_json}
-    STRING
+  def system_prompt_for_mode
+    chapter_options.chatgpt_dropper_story_system_prompt
   end
 
   def json_format
@@ -73,10 +67,6 @@ class ChatgptDropperService < ChatgptService
   end
 
   def reminder
-    "\n (reply in JSON RFC 8259 compliant format as instructed)"
-  end
-
-  def language_name
-    I18nData.languages(:en)[language]
+    ' (reply in JSON RFC 8259 compliant format as instructed)'
   end
 end

--- a/app/services/chatgpt_service.rb
+++ b/app/services/chatgpt_service.rb
@@ -10,4 +10,37 @@ class ChatgptService < ApplicationService
   def api_key
     Rails.application.credentials.chatgpt.api_key
   end
+
+  def minimum_chapters_count
+    chapter_options.minimum_chapters_count
+  end
+
+  def maximum_chapters_count
+    chapter_options.maximum_chapters_count
+  end
+
+  def chapter_options
+    @chapter_options ||= Setting.first.chapter_options
+  end
+
+  def language_name
+    I18nData.languages(:en)[language]
+  end
+
+  def system_prompt
+    prompt = system_prompt_for_mode
+             .gsub('{{language}}', language_name)
+             .gsub('{{minimum_chapters_count}}', minimum_chapters_count.to_s)
+             .gsub('{{maximum_chapters_count}}', maximum_chapters_count.to_s)
+
+    prompt + response_format
+  end
+
+  def response_format
+    <<~STRING.strip
+      Provide a RFC 8259 compliant JSON response following this format without deviation:
+
+      #{json_format.to_json}
+    STRING
+  end
 end

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -16,8 +16,9 @@
     <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
   </svg>
 
-  div.mr-3
-    p.text-xs.italic.mb-1.underline= l(Time.current)
+  div.pr-3
+    - unless disappear
+      p.text-xs.italic.mb-1.underline= l(Time.current)
     .max-h-64.overflow-y-scroll.max-w-sm= simple_format message
 
   - unless disappear

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -18,7 +18,7 @@ header.relative.z-20.border-b.bg-slate-800
 
         .peer-checked:translate-x-0.fixed.inset-0.bg-slate-800.border-r.shadow-xl.transition.duration-300.lg:border-r-0.lg:w-auto.lg:static.lg:shadow-none.lg:translate-x-0 class="w-[calc(100%-4.5rem)] translate-x-[-100%]"
           .flex.flex-col.h-full.justify-between.lg:items-center.lg:flex-row
-            ul.px-6.pt-32.text-gray-700.space-y-8.md:px-12.lg:space-y-0.lg:flex.lg:space-x-12.lg:pt-0
+            ul.px-6.pt-32.text-gray-700.space-y-8.md:px-12.lg:space-y-0.lg:flex.lg:space-x-8.lg:pt-0
               - link_class = 'group relative before:absolute before:inset-x-0 before:-bottom-2 before:h-2 before:origin-right before:scale-x-0 before:bg-white before:transition before:duration-200 hover:before:origin-left hover:before:scale-x-100 text-white'
               li
                 = link_to root_path, class: "#{link_class} #{'before:origin-left before:scale-x-100' if params[:controller] == 'homes'}" do
@@ -41,6 +41,12 @@ header.relative.z-20.border-b.bg-slate-800
                   = link_to thematics_path,
                             class: "#{link_class} #{'before:origin-left before:scale-x-100' if params[:controller] == 'thematics'}" do
                     span.relative.group-hover:text-white Thématiques
+
+              li
+                = link_to settings_path,
+                          class: "#{link_class} #{'before:origin-left before:scale-x-100' if params[:controller] == 'settings'}" do
+                  span.relative.group-hover:text-white Paramètres
+
 
             .border-t.py-8.px-6.md:px-12.md:py-16.lg:border-t-0.lg:border-l.lg:py-0.lg:pr-0.lg:pl-6
               .flex.items-center.gap-3.p-2

--- a/app/views/application/_quick_custom_story_generator.html.slim
+++ b/app/views/application/_quick_custom_story_generator.html.slim
@@ -1,7 +1,12 @@
 = simple_form_for Story.new,
                   url: stories_path,
                   html: { \
-                    class: 'flex flex-col items-center gap-6 justify-between p-4 bg-gray-200 rounded-b-lg' \
+                    class: 'flex flex-col items-center gap-6 justify-between p-4 bg-gray-200 rounded-b-lg', \
+                    data: { \
+                      controller: 'jumpto', \
+                      action: 'turbo:submit-end->jumpto#jump', \
+                      jumpto_div_id_value: 'stories' \
+                    } \
                   } do |f|
 
   .flex.flex-col.lg:flex-row.gap-3.justify-between

--- a/app/views/settings/_form.html.slim
+++ b/app/views/settings/_form.html.slim
@@ -1,0 +1,13 @@
+= simple_form_for @setting do |f|
+  = f.input :chapter_options,
+            input_html: { \
+              data: { \
+                controller: :settings, \
+                settings_chapter_options_value: f.object.chapter_options \
+              }, \
+              class: 'h-48', \
+              value: f.object.chapter_options.as_json \
+            }
+
+  .mt-6
+    = f.button :submit

--- a/app/views/settings/_setting.html.slim
+++ b/app/views/settings/_setting.html.slim
@@ -1,0 +1,6 @@
+div id=dom_id(setting)
+  p.mb-2
+    strong Chapter options:
+
+  pre.bg-gray-100.border.borer-gray-300.p-2.rounded-lg.overflow-x-auto
+    = JSON.pretty_generate(setting.chapter_options.as_json)

--- a/app/views/settings/edit.html.slim
+++ b/app/views/settings/edit.html.slim
@@ -1,0 +1,6 @@
+header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
+  h1.text-3xl Modifier les paramètres
+
+  = link_to '<< Retour', settings_path, class: 'back-link'
+
+= render 'form', setting: @setting

--- a/app/views/settings/show.html.slim
+++ b/app/views/settings/show.html.slim
@@ -1,0 +1,9 @@
+header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
+  h1.text-3xl Les paramètres
+
+  - if allowed_to?(:update?, Setting)
+    = link_to 'Modifier', edit_settings_path, class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-orange-700 rounded-lg hover:bg-orange-800 focus:ring-4 focus:outline-none focus:ring-orange-300'
+
+
+.mb-3
+  = render @setting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,4 +42,7 @@ Rails.application.routes.draw do
 
   resources :relays, except: :show
   resources :thematics, except: :show
+
+  resource :settings, only: %i[show edit update]
+  resolve('Setting') { [:settings] }
 end

--- a/db/migrate/20230814162338_create_settings.rb
+++ b/db/migrate/20230814162338_create_settings.rb
@@ -1,0 +1,9 @@
+class CreateSettings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :settings do |t|
+      t.jsonb :chapter_options, null: false, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_13_070638) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_14_162338) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_070638) do
     t.datetime "updated_at", null: false
     t.integer "position", default: 1, null: false
     t.index ["url"], name: "index_relays_on_url", unique: true
+  end
+
+  create_table "settings", force: :cascade do |t|
+    t.jsonb "chapter_options", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "stories", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,9 @@
 require 'open-uri'
 
+puts 'Seeding settings...'
+
+Setting.create!
+
 puts 'Seeding users...'
 
 avatar = Faker::LoremFlickr.image(size: '300x300', search_terms: ['avatar'])

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :setting
+end

--- a/spec/policies/setting_policy_spec.rb
+++ b/spec/policies/setting_policy_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SettingPolicy do
+  let(:user) { build_stubbed :user }
+  let(:record) { build_stubbed :setting }
+
+  let(:context) { { user: user } }
+
+  describe_rule :show? do
+    succeed 'allowed to show action'
+  end
+
+  describe_rule :edit? do
+    succeed 'allowed to edit action'
+  end
+
+  describe_rule :update? do
+    succeed 'allowed to update action'
+  end
+end

--- a/spec/requests/settings_controller_spec.rb
+++ b/spec/requests/settings_controller_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe SettingsController do
+  before { create :setting }
+
+  describe 'GET /settings' do
+    subject(:action) { get '/settings' }
+
+    it_behaves_like 'a user not logged in'
+
+    context 'when logged in', as: :logged_in do
+      before { action }
+
+      it { expect(response).to have_http_status :ok }
+    end
+  end
+
+  describe 'GET /settings/edit' do
+    subject(:action) { get '/settings/edit' }
+
+    include_examples 'a user not logged in'
+
+    context 'when logged in', as: :logged_in do
+      before { action }
+
+      it { expect(response).to have_http_status :ok }
+    end
+  end
+
+  describe 'PATCH /settings' do
+    subject(:action) do
+      patch '/settings', params: { setting: params }
+    end
+
+    let(:params) { {} }
+
+    include_examples 'a user not logged in'
+
+    context 'when logged in', as: :logged_in do
+      context 'when params are invalid' do
+        let(:params) do
+          { chapter_options: { stable_diffusion_prompt: nil }.to_json }
+        end
+
+        before { action }
+
+        it { expect(response).to have_http_status :unprocessable_entity }
+      end
+
+      context 'when params are valid' do
+        let(:params) do
+          { chapter_options: { stable_diffusion_prompt: 'a prompt' }.to_json }
+        end
+
+        include_examples 'a redirect response with success message' do
+          let(:message) { 'Setting was successfully updated.' }
+          let(:url_to_redirect) { settings_path }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This new model allows to register some project settings as `jsonb` type and easily manage them thanks to the `store_model` gem (validation friendly).

It handles some variables such as:
- minimum_chapters_count
- maximum_chapters_count
- chatgpt_full_story_system_prompt
- chatgpt_dropper_story_system_prompt
- stable_diffusion_prompt

More variables could be later added to the JSON object model without having to run migrations.