### PR TITLE
Add option to specify min and max sats on polls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,7 @@ Rails/I18nLocaleTexts:
 
 Rails/BulkChangeTable:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - spec/models/setting/chapter_option_spec.rb

--- a/app/models/setting/chapter_option.rb
+++ b/app/models/setting/chapter_option.rb
@@ -4,6 +4,8 @@ class Setting
 
     MINIMUM_CHAPTERS_COUNT = 4
     MAXIMUM_CHAPTERS_COUNT = 10
+    MINIMUM_POLL_SATS = 42
+    MAXIMUM_POLL_SATS = 420
     PUBLISH_PREVIOUS = false
     STABLE_DIFFUSION_PROMPT = 'Beautiful, elegant, highly detailed, realistic, depth'.freeze
     CHATGPT_FULL_STORY_SYSTEM_PROMPT = <<~PROMPT.strip.freeze
@@ -18,13 +20,15 @@ class Setting
               default: MINIMUM_CHAPTERS_COUNT
     attribute :maximum_chapters_count, :integer,
               default: MAXIMUM_CHAPTERS_COUNT
+    attribute :minimum_poll_sats, :integer, default: MINIMUM_POLL_SATS
+    attribute :maximum_poll_sats, :integer, default: MAXIMUM_POLL_SATS
+    attribute :publish_previous, :boolean, default: PUBLISH_PREVIOUS
     attribute :chatgpt_full_story_system_prompt, :string,
               default: CHATGPT_FULL_STORY_SYSTEM_PROMPT
     attribute :chatgpt_dropper_story_system_prompt, :string,
               default: CHATGPT_DROPPER_STORY_SYSTEM_PROMPT
     attribute :stable_diffusion_prompt, :string,
               default: STABLE_DIFFUSION_PROMPT
-    attribute :publish_previous, :boolean, default: PUBLISH_PREVIOUS
 
     validates :minimum_chapters_count,
               presence: true,
@@ -43,6 +47,25 @@ class Setting
     validates :stable_diffusion_prompt, presence: true
     validates :chatgpt_full_story_system_prompt, presence: true
     validates :chatgpt_dropper_story_system_prompt, presence: true
-    validates :publish_previous, presence: true, allow_blank: true, inclusion: [true, false]
+
+    validates :minimum_poll_sats,
+              presence: true,
+              numericality: {
+                greater_than_or_equal_to: MINIMUM_POLL_SATS,
+                less_than_or_equal_to: :maximum_poll_sats
+              }
+
+    validates :maximum_poll_sats,
+              presence: true,
+              numericality: {
+                less_than_or_equal_to: MAXIMUM_POLL_SATS,
+                greater_than_or_equal_to: :minimum_poll_sats
+              }
+
+    validates :publish_previous, allow_blank: false, inclusion: [true, false]
+
+    def publish_previous=(value)
+      super(value.to_bool)
+    end
   end
 end

--- a/app/services/nostr_event.rb
+++ b/app/services/nostr_event.rb
@@ -28,4 +28,8 @@ class NostrEvent < ApplicationService
   def nostr_user
     raise StandardError, 'NostrUser must be defined in subclasses'
   end
+
+  def options
+    @options ||= Setting.first.chapter_options
+  end
 end

--- a/app/services/nostr_services/chapter_poll_event.rb
+++ b/app/services/nostr_services/chapter_poll_event.rb
@@ -1,8 +1,6 @@
 module NostrServices
   class ChapterPollEvent < NostrEvent
     EVENT_KIND = 6969 # NIP-69
-    MINIMUM_SATS_VALUE = 42
-    MAXIMUM_SATS_VALUE = 420
     POLL_END_OF_LIFE = 1.hour
 
     attr_reader :chapter, :reference
@@ -41,13 +39,13 @@ module NostrServices
     def tags
       [
         ['p', public_key, favorite_relay_url],
-        ['value_minimum', MINIMUM_SATS_VALUE.to_s],
-        ['value_maximum', MAXIMUM_SATS_VALUE.to_s],
+        ['value_minimum', options.minimum_poll_sats.to_s],
+        ['value_maximum', options.maximum_poll_sats.to_s],
         ['closed_at', POLL_END_OF_LIFE.from_now.utc.to_i.to_s]
       ].tap do |data|
         data.push ['e', reference, favorite_relay_url] if reference
 
-        options.each_with_index do |option, index|
+        chapter.options.each_with_index do |option, index|
           data.push ['poll_option', index.to_s, option]
         end
       end
@@ -63,10 +61,6 @@ module NostrServices
 
         #{I18n.t('chapter_poll.poll_choice')}
       CONTENT
-    end
-
-    def options
-      chapter.options
     end
 
     def nostr_user

--- a/app/views/settings/_setting.html.slim
+++ b/app/views/settings/_setting.html.slim
@@ -17,12 +17,39 @@ div id=dom_id(setting)
             i=< Setting::ChapterOption::MINIMUM_CHAPTERS_COUNT
             | )
 
-        li.mb-2
+        li
           strong> maximum_chapters_count:
           | Nombre de chapitres maximum à générer
           span.bg-white.p-1.rounded-lg
             | (défaut:
             i=< Setting::ChapterOption::MAXIMUM_CHAPTERS_COUNT
+            | )
+
+        li
+          strong minimum_poll_sats:
+          |< Quantité de satoshis minimum à payer pour participer au sondage
+
+          span.bg-white.p-1.rounded-lg
+            | (défaut:
+            i=< Setting::ChapterOption::MINIMUM_POLL_SATS
+            | )
+
+        li
+          strong maximum_poll_sats:
+          |< Quantité de satoshis minimum à payer pour participer au sondage
+
+          span.bg-white.p-1.rounded-lg
+            | (défaut:
+            i=< Setting::ChapterOption::MAXIMUM_POLL_SATS
+            | )
+
+        li.mb-2
+          strong publish_previous:
+          |< Si un ou plusieurs précédents chapitres n'ont pas été publiés avant d'en générer un nouveau, doivent-ils être publiés avant ? Si non, une publication manuelle devra être faîte.
+
+          span.bg-white.p-1.rounded-lg
+            | (défaut:
+            i=< Setting::ChapterOption::PUBLISH_PREVIOUS
             | )
 
         li.mb-2
@@ -66,13 +93,5 @@ div id=dom_id(setting)
             i=< Setting::ChapterOption::CHATGPT_DROPPER_STORY_SYSTEM_PROMPT
             | )
 
-        li.mb-3
-          strong publish_previous:
-          |< Si un ou plusieurs précédents chapitres n'ont pas été publiés avant d'en générer un nouveau, doivent-ils être publiés avant ? Si non, une publication manuelle devra être faîte.
-
-          span.bg-white.p-1.rounded-lg
-            | (défaut:
-            i=< Setting::ChapterOption::PUBLISH_PREVIOUS
-            | )
 css:
   #{Pygments.css('.material-theme', style: :material)}

--- a/spec/models/setting/chapter_option_spec.rb
+++ b/spec/models/setting/chapter_option_spec.rb
@@ -1,0 +1,237 @@
+require 'rails_helper'
+
+RSpec.describe Setting::ChapterOption do
+  subject(:chapter_option) { described_class.to_type.cast_value(json_data) }
+
+  let(:json_data) do
+    {
+      minimum_chapters_count: minimum_chapters_count,
+      maximum_chapters_count: maximum_chapters_count,
+      chatgpt_full_story_system_prompt: chatgpt_full_story_system_prompt,
+      chatgpt_dropper_story_system_prompt: chatgpt_dropper_story_system_prompt,
+      stable_diffusion_prompt: stable_diffusion_prompt,
+      minimum_poll_sats: minimum_poll_sats,
+      maximum_poll_sats: maximum_poll_sats,
+      publish_previous: publish_previous,
+      foo: 'bar'
+    }
+  end
+
+  let(:minimum_chapters_count) { 4 }
+  let(:maximum_chapters_count) { 10 }
+  let(:chatgpt_full_story_system_prompt) { 'Foo bar' }
+  let(:chatgpt_dropper_story_system_prompt) { 'Bar foo' }
+  let(:stable_diffusion_prompt) { 'my, keywords, prompt' }
+  let(:minimum_poll_sats) { 42 }
+  let(:maximum_poll_sats) { 420 }
+  let(:publish_previous) { true }
+
+  it { expect(chapter_option.unknown_attributes).to include('foo' => 'bar') }
+
+  describe '#minimum_chapters_count' do
+    subject { chapter_option }
+
+    context 'when value is lower than maximum_chapters_count' do
+      let(:minimum_chapters_count) { 6 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(minimum_chapters_count: 6) }
+    end
+
+    context 'when value is equal to maximum_chapters_count' do
+      let(:minimum_chapters_count) { 10 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(minimum_chapters_count: 10) }
+    end
+
+    context 'when value is higher than maximum_chapters_count' do
+      let(:minimum_chapters_count) { 30 }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(minimum_chapters_count: 30) }
+    end
+  end
+
+  describe '#maximum_chapters_count' do
+    subject { chapter_option }
+
+    context 'when value is lower than minimum_chapters_count' do
+      let(:maximum_chapters_count) { 1 }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(maximum_chapters_count: 1) }
+    end
+
+    context 'when value is equal to minimum_chapters_count' do
+      let(:maximum_chapters_count) { 4 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(maximum_chapters_count: 4) }
+    end
+
+    context 'when value is higher than minimum_chapters_count' do
+      let(:maximum_chapters_count) { 9 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(maximum_chapters_count: 9) }
+    end
+  end
+
+  describe '#stable_diffusion_prompt' do
+    subject { chapter_option }
+
+    context 'when value is present' do
+      let(:stable_diffusion_prompt) { 'foo bar baz' }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(stable_diffusion_prompt: 'foo bar baz') }
+    end
+
+    context 'when value is blank' do
+      let(:stable_diffusion_prompt) { '' }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(stable_diffusion_prompt: '') }
+    end
+
+    context 'when value is nil' do
+      let(:stable_diffusion_prompt) { nil }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(stable_diffusion_prompt: nil) }
+    end
+  end
+
+  describe '#chatgpt_full_story_system_prompt' do
+    subject { chapter_option }
+
+    context 'when value is present' do
+      let(:chatgpt_full_story_system_prompt) { 'foo bar baz' }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(chatgpt_full_story_system_prompt: 'foo bar baz') }
+    end
+
+    context 'when value is blank' do
+      let(:chatgpt_full_story_system_prompt) { '' }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(chatgpt_full_story_system_prompt: '') }
+    end
+
+    context 'when value is nil' do
+      let(:chatgpt_full_story_system_prompt) { nil }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(chatgpt_full_story_system_prompt: nil) }
+    end
+  end
+
+  describe '#chatgpt_dropper_story_system_prompt' do
+    subject { chapter_option }
+
+    context 'when value is present' do
+      let(:chatgpt_dropper_story_system_prompt) { 'foo bar baz' }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(chatgpt_dropper_story_system_prompt: 'foo bar baz') }
+    end
+
+    context 'when value is blank' do
+      let(:chatgpt_dropper_story_system_prompt) { '' }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(chatgpt_dropper_story_system_prompt: '') }
+    end
+
+    context 'when value is nil' do
+      let(:chatgpt_dropper_story_system_prompt) { nil }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(chatgpt_dropper_story_system_prompt: nil) }
+    end
+  end
+
+  describe '#minimum_poll_sats' do
+    subject { chapter_option }
+
+    context 'when value is lower than maximum_poll_sats' do
+      let(:minimum_poll_sats) { 100 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(minimum_poll_sats: 100) }
+    end
+
+    context 'when value is equal to maximum_poll_sats' do
+      let(:minimum_poll_sats) { 420 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(minimum_poll_sats: 420) }
+    end
+
+    context 'when value is higher than maximum_poll_sats' do
+      let(:minimum_poll_sats) { 500 }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(minimum_poll_sats: 500) }
+    end
+  end
+
+  describe '#maximum_poll_sats' do
+    subject { chapter_option }
+
+    context 'when value is lower than minimum_poll_sats' do
+      let(:maximum_poll_sats) { 20 }
+
+      it { is_expected.to_not be_valid }
+      it { is_expected.to have_attributes(maximum_poll_sats: 20) }
+    end
+
+    context 'when value is equal to minimum_poll_sats' do
+      let(:maximum_poll_sats) { 42 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(maximum_poll_sats: 42) }
+    end
+
+    context 'when value is higher than minimum_poll_sats' do
+      let(:maximum_poll_sats) { 100 }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(maximum_poll_sats: 100) }
+    end
+  end
+
+  describe '#publish_previous' do
+    subject { chapter_option }
+
+    context 'when value is empty' do
+      let(:publish_previous) { nil }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(publish_previous: false) }
+    end
+
+    context 'when value is not a boolean' do
+      let(:publish_previous) { 'foo' }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(publish_previous: true) }
+    end
+
+    context 'when value is false boolean' do
+      let(:publish_previous) { false }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(publish_previous: false) }
+    end
+
+    context 'when value is true boolean' do
+      let(:publish_previous) { true }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(publish_previous: true) }
+    end
+  end
+end


### PR DESCRIPTION
Two new options have been added to configure satoshis minimum and maximum values to spent to participate to a poll:

- `minimum_poll_sats`
- `maximum_poll_sats`

Cover `Setting::ChapterOption` class with specs