### PR TITLE
Respond with `turbo_stream` format when generating cover

### DIFF
--- a/app/controllers/stories/chapters/covers_controller.rb
+++ b/app/controllers/stories/chapters/covers_controller.rb
@@ -11,13 +11,18 @@ module Stories
 
         ReplicateServices::Picture.call(@chapter, @chapter.summary)
 
-        redirect_to root_path, notice: "La couverture de l'histoire est en cours de création"
+        respond_to do |format|
+          notice = 'La couverture du chapitre est en cours de création'
+
+          format.html { redirect_to root_path, notice: notice }
+          format.turbo_stream { flash.now[:notice] = notice }
+        end
       end
 
       private
 
       def set_story
-        @story = Story.enabled.find(params[:story_id])
+        @story = Story.find(params[:story_id])
       end
 
       def set_chapter

--- a/app/controllers/stories/covers_controller.rb
+++ b/app/controllers/stories/covers_controller.rb
@@ -9,13 +9,18 @@ module Stories
 
       ReplicateServices::Picture.call(@story, @story.summary)
 
-      redirect_to root_path, notice: "La couverture de l'histoire est en cours de création"
+      respond_to do |format|
+        notice = "La couverture de l'histoire est en cours de création"
+
+        format.html { redirect_to root_path, notice: notice }
+        format.turbo_stream { flash.now[:notice] = notice }
+      end
     end
 
     private
 
     def set_story
-      @story = Story.enabled.find(params[:story_id])
+      @story = Story.find(params[:story_id])
     end
   end
 end

--- a/app/policies/chapters/cover_policy.rb
+++ b/app/policies/chapters/cover_policy.rb
@@ -1,7 +1,9 @@
 module Chapters
   class CoverPolicy < ApplicationPolicy
+    pre_check :allow_admins
+
     def update?
-      !chapter.published?
+      chapter.story.enabled? && !chapter.published?
     end
 
     private

--- a/app/policies/stories/cover_policy.rb
+++ b/app/policies/stories/cover_policy.rb
@@ -1,7 +1,9 @@
 module Stories
   class CoverPolicy < ApplicationPolicy
+    pre_check :allow_admins
+
     def update?
-      !story.current?
+      story.enabled? && !story.current? && !story.ended?
     end
 
     private

--- a/app/views/stories/chapters/covers/update.turbo_stream.slim
+++ b/app/views/stories/chapters/covers/update.turbo_stream.slim
@@ -1,0 +1,1 @@
+= render_turbo_stream_flash_messages

--- a/app/views/stories/covers/update.turbo_stream.slim
+++ b/app/views/stories/covers/update.turbo_stream.slim
@@ -1,0 +1,1 @@
+= render_turbo_stream_flash_messages

--- a/spec/factories/chapters.rb
+++ b/spec/factories/chapters.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :chapter do
+    summary { Faker::Lorem.sentence }
+
+    story
+
+    trait :published do
+      published_at { 1.day.ago }
+    end
+  end
+end

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -1,6 +1,22 @@
 FactoryBot.define do
   factory :story do
+    summary { Faker::Lorem.sentence }
+
     thematic
     nostr_user
+
+    trait :disabled do
+      enabled { false }
+    end
+
+    trait :published do
+      after(:create) do |story|
+        create_list :chapter, 2, :published, story: story
+      end
+    end
+
+    trait :ended do
+      adventure_ended_at { 1.day.ago }
+    end
   end
 end

--- a/spec/policies/chapters/cover_policy_spec.rb
+++ b/spec/policies/chapters/cover_policy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Chapters::CoverPolicy do
+  let(:user) { build_stubbed :user, role }
+
+  let(:story) { build_stubbed :story }
+  let(:record) { build_stubbed :chapter, story: story }
+
+  let(:context) { { user: user } }
+
+  describe_rule :update? do
+    %i[admin super_admin].each do |user_role|
+      succeed "when user is #{user_role}" do
+        let(:role) { user_role }
+
+        failed 'when chapter is already published' do
+          let(:record) { build_stubbed :chapter, :published }
+        end
+
+        failed 'when story is disabled' do
+          let(:story) { build_stubbed :story, :disabled }
+        end
+      end
+    end
+
+    failed 'when user is standard' do
+      let(:role) { :standard }
+    end
+  end
+end

--- a/spec/policies/stories/cover_policy_spec.rb
+++ b/spec/policies/stories/cover_policy_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Stories::CoverPolicy do
+  let(:user) { build_stubbed :user, role }
+
+  let(:record) { create :story }
+  let(:context) { { user: user } }
+
+  describe_rule :update? do
+    %i[admin super_admin].each do |user_role|
+      succeed "when user is #{user_role}" do
+        let(:role) { user_role }
+
+        failed 'when story is already published' do
+          let(:record) { create :story, :published }
+        end
+
+        failed 'when story is disabled' do
+          let(:record) { create :story, :disabled }
+        end
+
+        failed 'when story is ended' do
+          let(:record) { create :story, :ended }
+        end
+      end
+    end
+
+    failed 'when user is standard' do
+      let(:role) { :standard }
+    end
+  end
+end

--- a/spec/requests/stories/chapters/covers_controller_spec.rb
+++ b/spec/requests/stories/chapters/covers_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Stories::Chapters::CoversController do
+  describe 'PATCH /stories/:story_id/chapters/:chapter_id/covers' do
+    subject(:action) { patch "/stories/#{story.id}/chapters/#{chapter.id}/covers" }
+
+    let(:story) { create :story }
+    let(:chapter) { create :chapter, story: story, summary: 'my chapter summary' }
+
+    before do
+      allow(ReplicateServices::Picture).to receive(:call)
+    end
+
+    it_behaves_like 'a user not logged in'
+    it_behaves_like 'unauthorized request when logged in as standard'
+
+    context 'when logged in with proper accreditation', as: :logged_in do
+      let(:role) { :admin }
+
+      describe '[replicate service]' do
+        before { action }
+
+        it { expect(ReplicateServices::Picture).to have_received(:call).with(chapter, 'my chapter summary') }
+      end
+
+      include_examples 'a redirect response with success message' do
+        let(:message) { 'La couverture du chapitre est en cours de création' }
+        let(:url_to_redirect) { root_path }
+      end
+    end
+  end
+end

--- a/spec/requests/stories/covers_controller_spec.rb
+++ b/spec/requests/stories/covers_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Stories::CoversController do
+  describe 'PATCH /stories/:story_id/covers' do
+    subject(:action) { patch "/stories/#{story.id}/covers" }
+
+    let(:story) { create :story, summary: 'my story summary' }
+
+    before do
+      allow(ReplicateServices::Picture).to receive(:call)
+    end
+
+    it_behaves_like 'a user not logged in'
+    it_behaves_like 'unauthorized request when logged in as standard'
+
+    context 'when logged in with proper accreditation', as: :logged_in do
+      let(:role) { :admin }
+
+      describe '[replicate service]' do
+        before { action }
+
+        it { expect(ReplicateServices::Picture).to have_received(:call).with(story, 'my story summary') }
+      end
+
+      include_examples 'a redirect response with success message' do
+        let(:message) { "La couverture de l'histoire est en cours de création" }
+        let(:url_to_redirect) { root_path }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Avoid a redirection and a jump to the top of the page by responding directly with `turbo_stream` format.

Add related stories and chapters covers controller and policies specs.