### PR TITLE
Nostr accounts

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -118,6 +118,10 @@ input.boolean, input.check_boxes {
   @apply back-link !bg-red-700;
 }
 
+.blue-button {
+  @apply back-link !bg-blue-700;
+}
+
 .material-theme {
   @apply p-3 rounded-lg overflow-x-auto;
 }

--- a/app/controllers/nostr_users/import_profiles_controller.rb
+++ b/app/controllers/nostr_users/import_profiles_controller.rb
@@ -1,0 +1,34 @@
+module NostrUsers
+  class ImportProfilesController < ApplicationController
+    # @route GET /nostr_users/import_profiles/new (new_import_profiles)
+    def new
+      authorize! NostrUser
+
+      @nostr_user = NostrUser.new
+    end
+
+    # @route POST /nostr_users/import_profiles (import_profiles)
+    def create
+      authorize! NostrUser
+
+      @nostr_user = NostrUser.new(nostr_user_params) do |nostr_user|
+        nostr_user.mode = :imported
+      end
+
+      if @nostr_user.save
+        NostrAccounts::ImportAccount.call(@nostr_user)
+
+        redirect_to nostr_users_path, notice: 'Nostr user was successfully imported.'
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def nostr_user_params
+      params.require(:nostr_user)
+            .permit(:private_key, :language, :enabled, relay_ids: [])
+    end
+  end
+end

--- a/app/controllers/nostr_users/private_keys_controller.rb
+++ b/app/controllers/nostr_users/private_keys_controller.rb
@@ -1,0 +1,38 @@
+module NostrUsers
+  class PrivateKeysController < ApplicationController
+    before_action :set_nostr_user
+
+    # @route GET /nostr_users/:id/private_keys/ask_password (ask_password_private_keys)
+    def ask_password
+      authorize! @nostr_user, with: PrivateKeyPolicy
+    end
+
+    # @route POST /nostr_users/:id/private_keys/reveal (reveal_private_keys)
+    def reveal
+      authorize! @nostr_user, with: PrivateKeyPolicy
+
+      if current_user.valid_password?(user_password)
+        nostr = Nostr.new(private_key: @nostr_user.private_key)
+        @nsec = nostr.bech32_keys[:private_key]
+      else
+        @nostr_user.errors.add(:user_password, 'Mot de passe invalide')
+
+        render :ask_password, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def nostr_user_params
+      params.require(:nostr_user).permit(:user_password)
+    end
+
+    def user_password
+      nostr_user_params[:user_password]
+    end
+
+    def set_nostr_user
+      @nostr_user = NostrUser.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/nostr_users/refresh_profiles_controller.rb
+++ b/app/controllers/nostr_users/refresh_profiles_controller.rb
@@ -4,11 +4,9 @@ module NostrUsers
 
     # @route POST /nostr_users/:id/refresh_profiles (refresh_profiles)
     def create
-      authorize! @nostr_user, with: NostrUsers::ProfilePolicy
+      authorize! @nostr_user, with: ProfilePolicy
 
-      response = NostrServices::FetchProfile.call(@nostr_user)
-
-      @nostr_user.update(metadata_response: response)
+      NostrAccounts::ImportProfile.call(@nostr_user)
 
       redirect_to nostr_users_path, notice: 'Les métadonnées du profil ont bien été rafraîchies'
     rescue URI::InvalidURIError,

--- a/app/exceptions/nostr_user_errors.rb
+++ b/app/exceptions/nostr_user_errors.rb
@@ -1,5 +1,6 @@
 class NostrUserErrors < BaseErrors
   MissingAssociatedRelay = Class.new(self)
+  EmptyLightningNetworkAddress = Class.new(self)
 
   BotMissing = Class.new(self) do
     attr_reader :language

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,17 +29,10 @@ module ApplicationHelper
     end
   end
 
-  def nostr_user_languages_select_options(nostr_user = nil)
+  def nostr_user_languages_select_options
     all_languages = I18nData.languages(I18n.locale)
 
-    scope = NostrUser.all
-    scope = scope.excluding(nostr_user) if nostr_user
-
-    taken_languages = scope.map(&:language)
-
-    available_locales = all_languages.except(*taken_languages)
-
-    available_locales.map do |code, name|
+    all_languages.map do |code, name|
       ["#{name.capitalize} (#{code})", code]
     end
   end

--- a/app/javascript/controllers/private_keys_controller.js
+++ b/app/javascript/controllers/private_keys_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static classes = ['blur']
+
+  toggleValue(e) {
+    e.currentTarget.classList.toggle(this.blurClass)
+  }
+}

--- a/app/jobs/generate_dropper_story_job.rb
+++ b/app/jobs/generate_dropper_story_job.rb
@@ -15,6 +15,12 @@ class GenerateDropperStoryJob < GenerateStoryJob
 
   private
 
+  def validate!(draft_story)
+    super(draft_story)
+
+    raise NostrUserErrors::EmptyLightningNetworkAddress if draft_story.nostr_user.lud16.blank?
+  end
+
   def options
     @options ||= Setting.first.chapter_options
   end

--- a/app/models/nostr_profile.rb
+++ b/app/models/nostr_profile.rb
@@ -8,6 +8,9 @@ class NostrProfile
   attribute :picture, :string
   attribute :banner, :string
   attribute :about, :string
+  attribute :nip05, :string
+  attribute :lud16, :string
+  attribute :website, :string
 
   def identity
     display_name || name || DEFAULT_IDENTITY

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -12,6 +12,10 @@ class Relay < ApplicationRecord
   after_validation :clean_url
   after_update :delete_nostr_users_association, if: :marked_as_disabled?
 
+  def self.main
+    enabled.by_position.first
+  end
+
   # NOTE: title is used as alias to get correct form label association
   def title
     url

--- a/app/policies/nostr_users/private_key_policy.rb
+++ b/app/policies/nostr_users/private_key_policy.rb
@@ -1,0 +1,13 @@
+module NostrUsers
+  class PrivateKeyPolicy < ApplicationPolicy
+    pre_check :allow_super_admins
+
+    def ask_password?
+      true
+    end
+
+    def reveal?
+      true
+    end
+  end
+end

--- a/app/services/chatgpt_complete_service.rb
+++ b/app/services/chatgpt_complete_service.rb
@@ -61,6 +61,6 @@ class ChatgptCompleteService < ChatgptService
   end
 
   def reminder
-    'Ensure the story is complete and have a real coherent ending. Also reply in JSON RFC 8259 compliant format as instructed'
+    " Ensure the story is complete and have a real coherent ending. Also reply in JSON RFC 8259 compliant format as instructed. Respond in #{language_name} language only."
   end
 end

--- a/app/services/chatgpt_dropper_service.rb
+++ b/app/services/chatgpt_dropper_service.rb
@@ -67,6 +67,6 @@ class ChatgptDropperService < ChatgptService
   end
 
   def reminder
-    ' (reply in JSON RFC 8259 compliant format as instructed)'
+    " Reply in JSON RFC 8259 compliant format as instructed, respond in #{language_name} language only."
   end
 end

--- a/app/services/nostr_accounts/import_profile.rb
+++ b/app/services/nostr_accounts/import_profile.rb
@@ -1,0 +1,39 @@
+require 'open-uri'
+
+module NostrAccounts
+  class ImportProfile < ApplicationService
+    attr_reader :nostr_user
+
+    def initialize(nostr_user)
+      @nostr_user = nostr_user
+    end
+
+    def call
+      nostr_user.metadata_response = metadata
+
+      nostr_user.name = nostr_user.metadata_response.identity
+      nostr_user.about = nostr_user.metadata_response.about
+      nostr_user.nip05 = nostr_user.metadata_response.nip05
+      nostr_user.lud16 = nostr_user.metadata_response.lud16
+      nostr_user.website = nostr_user.metadata_response.website
+
+      nostr_user.banner = {
+        io: URI.parse(nostr_user.metadata_response.banner).open,
+        filename: 'user_banner'
+      }
+
+      nostr_user.picture = {
+        io: URI.parse(nostr_user.metadata_response.picture).open,
+        filename: 'user_picture'
+      }
+
+      nostr_user.save!
+    end
+
+    private
+
+    def metadata
+      @metadata ||= NostrServices::FetchProfile.call(nostr_user)
+    end
+  end
+end

--- a/app/services/nostr_accounts/publish_profile.rb
+++ b/app/services/nostr_accounts/publish_profile.rb
@@ -1,0 +1,37 @@
+module NostrAccounts
+  class PublishProfile < ApplicationService
+    include Rails.application.routes.url_helpers
+
+    attr_reader :nostr_user
+
+    def initialize(nostr_user)
+      @nostr_user = nostr_user
+    end
+
+    def build_and_publish_event
+      picture = nostr_user.picture.attached? ? polymorphic_url(nostr_user.picture, port: nil, host: ENV.fetch('HOST', nil)) : nil
+      banner = nostr_user.banner.attached? ? polymorphic_url(nostr_user.banner, port: nil, host: ENV.fetch('HOST', nil)) : nil
+
+      metadata = nostr.build_metadata_event(
+        name: nostr_user.name,
+        about: nostr_user.about,
+        picture: picture,
+        banner: banner,
+        nip05: nostr_user.nip05,
+        lud16: nostr_user.lud16,
+        website: nostr_user.website
+      )
+
+      nostr.test_post_event(metadata, Relay.main.url)
+
+      content = JSON.parse(metadata.last[:content])
+      nostr_user.update(metadata_response: content)
+    end
+
+    private
+
+    def nostr
+      @nostr ||= Nostr.new(private_key: nostr_user.private_key)
+    end
+  end
+end

--- a/app/services/nostr_services/fetch_profile.rb
+++ b/app/services/nostr_services/fetch_profile.rb
@@ -10,7 +10,7 @@ module NostrServices
 
     def call
       req = nostr.build_req_event(filters)
-      response = test_post_event(req, favorite_relay_url)
+      response = nostr.test_post_event(req, favorite_relay_url)
 
       JSON.parse(response.last['content'])
     end
@@ -20,32 +20,5 @@ module NostrServices
     def filters
       { kinds: [METADATA_KIND], authors: [public_key], limit: 1 }
     end
-
-    # :nocov:
-    # NOTE: This method has been extracted from `nostr_ruby` gem to fix
-    # a crash with invalid encoding characters.
-    def test_post_event(event, relay)
-      response = nil
-      ws = WebSocket::Client::Simple.connect(relay)
-
-      ws.on :open do
-        ws.send event.to_json
-      end
-
-      ws.on :message do |msg|
-        response = JSON.parse(msg.data.force_encoding('UTF-8'))
-        ws.close
-      end
-
-      ws.on :error do |e|
-        debug_logger('WebSocket Error', e, :red)
-        ws.close
-      end
-
-      sleep 0.1 while response.nil?
-
-      response
-    end
-    # :nocov:
   end
 end

--- a/app/views/homes/_stories.html.slim
+++ b/app/views/homes/_stories.html.slim
@@ -7,10 +7,14 @@ ul#quick_look role="list"
         .flex.items-center.gap-3
           div
             - if nostr_user.profile.picture
-              = image_tag nostr_user.profile.picture, class: 'w-12 mx-auto mb-1 rounded-full'
+              = image_tag polymorphic_path(nostr_user.picture), class: 'w-12 mx-auto mb-1 rounded-full bg-white'
           div
             p Une nouvelle aventure sera créée à la prochaine exécution de la tâche
-            p.text-xs= nostr_user.profile.identity
+            p.text-xs
+              = nostr_user.profile.identity
+
+              span.inline-block.text-xs.font-medium.p-1.rounded.bg-gray-100.text-gray-800.ml-2
+                = nostr_user.human_language
 
     - else
       - active_chapter = story.chapters.not_published.first
@@ -46,5 +50,8 @@ ul#quick_look role="list"
 
         .text-base.font-semibold.text-gray-900
           - if story.nostr_user.profile.picture
-            = image_tag story.nostr_user.profile.picture, class: 'w-24 mx-auto mb-1 rounded-full'
+            = image_tag polymorphic_path(story.nostr_user.picture), class: 'w-24 mx-auto mb-1 rounded-full'
+
           p= story.nostr_user.profile.identity
+          p.inline-block.text-xs.font-medium.p-1.rounded.bg-blue-500.text-white.ml-2
+            = story.nostr_user.human_language

--- a/app/views/nostr_users/_form.html.slim
+++ b/app/views/nostr_users/_form.html.slim
@@ -1,25 +1,53 @@
 = simple_form_for(nostr_user) do |f|
-  .form-inputs
-    = f.input :private_key,
-              as: :password,
-              input_html: { value: f.object.private_key },
-              wrapper_html: { class: 'mb-5' }
+  .flex.flex-col.items-start.lg:flex-row.justify-between.gap-5
+    div
+      .flex.items-center.justify-between.gap-3.mb-5
+        = f.input :name,
+                  wrapper_html: { class: 'w-1/2' }
 
-    = f.input :language,
-              as: :select,
-              collection: nostr_user_languages_select_options(f.object),
-              include_blank: false,
-              wrapper_html: { class: 'mb-5' }
+        = f.input :language,
+                  as: :select,
+                  collection: nostr_user_languages_select_options,
+                  include_blank: false,
+                  wrapper_html: { class: 'w-1/2' }
 
-    = f.association :relays,
-                    collection: Relay.enabled,
-                    as: :check_boxes,
-                    input_html: { class: 'ml-4 mr-1' },
-                    wrapper_html: { class: 'block mb-5' }
+      = f.input :about,
+                input_html: { class: 'h-32' },
+                wrapper_html: { class: ' mb-5' }
 
-    = f.input :enabled,
-              as: :boolean,
-              wrapper_html: { class: 'mb-5' }
+      .flex.flex-col.lg:flex-row.justify-between.gap-3.mb-8
+        = f.input :nip05,
+                  as: :email,
+                  wrapper_html: { class: 'w-full lg:w-1/3' }
 
-  .form-actions
-    = f.button :submit
+        = f.input :lud16,
+                  as: :email,
+                  wrapper_html: { class: 'w-full lg:w-1/3' }
+
+        = f.input :website,
+                  wrapper_html: { class: 'w-full lg:w-1/3' }
+
+    .flex.flex-col.justify-center.gap-12.mb-5
+      div
+        = f.input :picture, as: :file
+
+        - if f.object.picture.attached?
+          = image_tag polymorphic_path(f.object.picture), class: 'mx-auto mt-3 w-40 rounded-full'
+
+      div
+        = f.input :banner, as: :file
+
+        - if f.object.banner.attached?
+          = image_tag polymorphic_path(f.object.banner), class: 'mx-auto mt-3 w-96'
+
+  = f.association :relays,
+                  collection: Relay.enabled,
+                  as: :check_boxes,
+                  input_html: { class: 'ml-4 mr-1' },
+                  wrapper_html: { class: 'block mb-5' }
+
+  = f.input :enabled,
+            as: :boolean,
+            wrapper_html: { class: 'mb-5' }
+
+  = f.button :submit

--- a/app/views/nostr_users/_nostr_user.html.slim
+++ b/app/views/nostr_users/_nostr_user.html.slim
@@ -1,38 +1,115 @@
-.w-full.bg-white.rounded-lg.shadow id=dom_id(nostr_user)
-  - if nostr_user.profile.banner.present?
-    = image_tag nostr_user.profile.banner, class: 'w-full rounded-t-lg'
+- if params[:view] == 'grid'
+  .w-full.bg-white.rounded-lg.shadow id=dom_id(nostr_user)
+    - if nostr_user.banner.attached?
+      = image_tag polymorphic_path(nostr_user.banner), class: 'w-full rounded-t-lg max-h-60'
+    - elsif nostr_user.profile.banner.present?
+      = image_tag nostr_user.profile.banner, class: 'w-full rounded-t-lg'
 
-  .flex.flex-col.items-center.py-5.border.border-gray-200.relative
-    span.bg-blue-500.rounded-md.px-2.py-1.mr-1.text-xs.absolute.top-2.left-2.text-white
-          = I18nData.languages(I18n.locale)[nostr_user.language.upcase].capitalize
+    .flex.flex-col.items-center.p-5.relative
+      span.bg-blue-500.rounded-md.px-2.py-1.mr-1.text-xs.absolute.top-2.left-2.text-white
+        = I18nData.languages(I18n.locale)[nostr_user.language.upcase].capitalize
 
-    - if nostr_user.profile.picture.present?
-      = image_tag nostr_user.profile.picture, class: 'w-24 h-24 mb-3 rounded-full shadow-lg'
+      - if nostr_user.picture.attached?
+        = image_tag polymorphic_path(nostr_user.picture), class: 'w-24 h-24 mb-3 rounded-full shadow-lg'
+      - elsif nostr_user.profile.picture.present?
+        = image_tag nostr_user.profile.picture, class: 'w-24 h-24 mb-3 rounded-full shadow-lg'
 
-    h5.mb-1.text-xl.font-medium.text-gray-900
-      = nostr_user.profile.identity
+      h5.mb-1.text-xl.font-medium.text-gray-900
+        = nostr_user.profile.identity
 
-    span.text-sm.text-gray-500.mb-2
-      = nostr_user.profile.about
+      span.text-sm.text-gray-500.mb-5
+        = nostr_user.profile.about
 
-    span.text-sm.text-gray-500.mb-5
-      = nostr_user.public_key
+      span.text-sm.text-gray-500.mb-1
+        | 🔑
+        =< nostr_user.public_key
 
-    span.text-sm.text-gray-500.mb-2
-      - nostr_user.relays.each do |relay|
-        span.bg-gray-200.rounded-md.px-2.py-1.mr-1= relay.url
+      - if nostr_user.lud16.present?
+        span.text-sm.text-gray-500
+          | ⚡
+          =< nostr_user.lud16
 
-    .flex.mt-4.space-x-3.md:mt-6
-      - if allowed_to?(:edit?, nostr_user)
-        = link_to 'Modifier', edit_nostr_user_path(nostr_user), class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-gray-900 bg-white border border-gray-300 rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-200'
+      span.text-sm.text-gray-500.mt-5.mb-2
+        - nostr_user.relays.each do |relay|
+          span.bg-gray-200.rounded-md.px-2.py-1.mr-1= relay.url
 
-      - if allowed_to?(:create?, nostr_user, with: NostrUsers::ProfilePolicy)
-        = button_to 'Rafraîchir les métadonnées',
-                    refresh_profiles_path(nostr_user),
-                    class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-gray-900 bg-orange-500 border border-orange-300 rounded-lg hover:bg-orange-100 focus:ring-4 focus:outline-none focus:ring-orange-200',
-                    data: { turbo_confirm: 'Voulez-vous rafraîchir les métadonnées ?' }
-      - if allowed_to?(:destroy?, nostr_user)
-        = button_to 'Supprimer', nostr_user,
-                    class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white-900 bg-red-500 border border-red-300 rounded-lg hover:bg-red-100 focus:ring-4 focus:outline-none focus:ring-red-200',
-                    method: :delete,
-                    data: { turbo_confirm: 'Voulez-vous supprimer ce compte Nostr ?' }
+      .flex.mt-4.space-x-3.md:mt-6
+        - if allowed_to?(:edit?, nostr_user)
+          = link_to 'Modifier', edit_nostr_user_path(nostr_user), class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-gray-900 bg-white border border-gray-300 rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-200'
+
+        - if allowed_to?(:create?, nostr_user, with: NostrUsers::ProfilePolicy)
+          = button_to 'Rafraîchir les métadonnées',
+                      refresh_profiles_path(nostr_user),
+                      class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-gray-900 bg-orange-500 border border-orange-300 rounded-lg hover:bg-orange-100 focus:ring-4 focus:outline-none focus:ring-orange-200',
+                      data: { turbo_confirm: 'Voulez-vous rafraîchir les métadonnées ?' }
+        - if allowed_to?(:destroy?, nostr_user)
+          = button_to 'Supprimer', nostr_user,
+                      class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white-900 bg-red-500 border border-red-300 rounded-lg hover:bg-red-100 focus:ring-4 focus:outline-none focus:ring-red-200',
+                      method: :delete,
+                      data: { turbo_confirm: 'Voulez-vous supprimer ce compte Nostr ?' }
+
+- else
+  details.border.mb-3.rounded-lg.border-gray-300.bg-gray-50 id=dom_id(nostr_user) class=('opacity-50' unless nostr_user.enabled?)
+    summary.flex.items-center.gap-3.justify-between.p-2.relative
+      .flex.items-center.gap-3
+        - if nostr_user.picture.attached?
+          = image_tag polymorphic_path(nostr_user.picture), class: 'w-20 rounded-full'
+        div
+          p.mb-1
+            = nostr_user.name
+            span.bg-blue-500.rounded-md.px-2.py-1.ml-1.text-xs.text-white<
+              = I18nData.languages(I18n.locale)[nostr_user.language.upcase].capitalize
+          p.text-sm.text-gray-700
+            | 🔑
+            =< link_to nostr_user.public_key, "#{nostr_client_url}/p/#{nostr_user.public_key}", target: :_blank, class: 'decoration-dashed'
+          - if nostr_user.lud16.present?
+            p.text-sm
+              | ⚡
+              =< nostr_user.lud16
+
+      .flex.items-center.gap-3
+        - if allowed_to?(:create?, nostr_user, with: NostrUsers::ProfilePolicy)
+          = button_to '🔄',
+                      refresh_profiles_path(nostr_user),
+                      class: 'blue-button',
+                      title: 'Rafraîchir les métadonnées depuis Nostr',
+                      data: { turbo_confirm: 'Voulez-vous rafraîchir les métadonnées ?' }
+
+        - if allowed_to?(:update?, nostr_user)
+          => link_to 'Modifier', edit_nostr_user_path(nostr_user), class: 'edit-link'
+
+        - if allowed_to?(:destroy?, nostr_user)
+          = button_to 'Supprimer', nostr_user,
+                      class: 'destroy-button',
+                      method: :delete,
+                      data: { turbo_confirm: 'Voulez-vous supprimer cette thématique ?' }
+
+    div
+      .flex.gap-3.p-3.text-gray-600.border-t
+        - if nostr_user.banner.attached?
+          = image_tag polymorphic_path(nostr_user.banner), class: 'w-96 rounded-lg'
+
+        .mb-3
+          .text-gray-500= nostr_user.about
+
+          - if nostr_user.nip05.present?
+            p.mt-3
+              | NIP05:
+              =< nostr_user.nip05
+
+          - if nostr_user.website.present?
+            p
+              | Site internet:
+              =< link_to nostr_user.website, nostr_user.website, target: :_blank
+
+      - if allowed_to?(:reveal?, nostr_user, with: NostrUsers::PrivateKeyPolicy)
+        section.border.text-red-500.bg-red-50.border-red-800.px-5.py-3.rounded-b-lg
+          p.text-lg.mb-3 ⚠️ Zone de danger ⚠️
+
+          = turbo_frame_tag dom_id(nostr_user, :private_key) do
+            = link_to 'Révéler la clé privée 🔑',
+                      ask_password_private_keys_path(nostr_user),
+                      class: 'inline-block bg-red-600 text-white p-2 rounded-lg'
+
+            - if nostr_user.generated?
+              p.italic.text-sm.mt-1 Assurez-vous d'avoir fait une sauvegarde de votre clé privée pour retrouver votre compte

--- a/app/views/nostr_users/import_profiles/_form.html.slim
+++ b/app/views/nostr_users/import_profiles/_form.html.slim
@@ -1,0 +1,25 @@
+= simple_form_for(nostr_user, url: import_profiles_path) do |f|
+  .form-inputs
+    = f.input :private_key,
+              as: :password,
+              input_html: { value: f.object.private_key },
+              wrapper_html: { class: 'mb-5' }
+
+    = f.input :language,
+              as: :select,
+              collection: nostr_user_languages_select_options,
+              include_blank: false,
+              wrapper_html: { class: 'mb-5' }
+
+    = f.association :relays,
+                    collection: Relay.enabled,
+                    as: :check_boxes,
+                    input_html: { class: 'ml-4 mr-1' },
+                    wrapper_html: { class: 'block mb-5' }
+
+    = f.input :enabled,
+              as: :boolean,
+              wrapper_html: { class: 'mb-5' }
+
+  .form-actions
+    = f.button :submit

--- a/app/views/nostr_users/import_profiles/new.html.slim
+++ b/app/views/nostr_users/import_profiles/new.html.slim
@@ -1,5 +1,5 @@
 header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
-  h1.text-3xl Créer un compte Nostr
+  h1.text-3xl Importer un compte Nostr avec une clé privée
 
   = link_to '<< Retour', nostr_users_path, class: 'back-link'
 

--- a/app/views/nostr_users/index.html.slim
+++ b/app/views/nostr_users/index.html.slim
@@ -1,10 +1,19 @@
 = turbo_stream_from :nostr_users
 
 header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
-  h1.text-3xl Comptes Nostr
+  .flex.items-end.gap-3
+    h1.text-3xl Comptes Nostr
+
+    p
+      span= link_to 'Ligne', nostr_users_path(view: :row), class: ('underline' if params[:view] == 'row' || params[:view].blank?)
+      |>< /
+      span= link_to 'Grille', nostr_users_path(view: :grid), class: ('underline' if params[:view] == 'grid')
 
   - if allowed_to?(:create?, NostrUser)
-    = link_to 'Ajouter un compte Nostr', new_nostr_user_path, class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-green-700 rounded-lg hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300'
+    .flex.items-center.gap-3
+      = link_to 'Créer un compte Nostr', new_nostr_user_path, class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-green-700 rounded-lg hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300'
+
+      = link_to 'Importer un compte Nostr', new_import_profiles_path, class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300'
 
 - if Relay.none?
   p.bg-red-200.border.border-red-600.p-2.rounded-lg
@@ -19,5 +28,5 @@ header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
     | au moins un relay pour gérer un compte Nostr
 
 - else
-  #nostr_users.grid.grid-cols-2.gap-3
+  #nostr_users class=('grid grid-cols-2 gap-3' if params[:view] == 'grid')
     = render @nostr_users

--- a/app/views/nostr_users/private_keys/ask_password.html.slim
+++ b/app/views/nostr_users/private_keys/ask_password.html.slim
@@ -1,0 +1,11 @@
+= turbo_frame_tag dom_id(@nostr_user, :private_key) do
+  = simple_form_for @nostr_user, url: reveal_private_keys_path(@nostr_user), html: { class: 'flex' }, method: :post do |f|
+    = f.input :user_password,
+              as: :password,
+              label: false,
+              placeholder: 'Veuillez saisir votre mot de passe utilisateur pour révéler la clé privée',
+              input_html: { class: 'w-full', autofocus: true },
+              wrapper_html: { class: 'w-1/2' }
+
+    = f.button :submit, 'Révéler 🔑',
+               class: 'bg-red-600 text-white rounded-lg ml-2 cursor-pointer'

--- a/app/views/nostr_users/private_keys/reveal.turbo_stream.slim
+++ b/app/views/nostr_users/private_keys/reveal.turbo_stream.slim
@@ -1,0 +1,5 @@
+= turbo_stream.update dom_id(@nostr_user, :private_key) do
+  p data-controller="private-keys" data-private-keys-blur-class="blur"
+    | Clé privée
+    span.bg-red-400.text-white.p-1.ml-1.rounded-lg.cursor-pointer.blur data-action="click->private-keys#toggleValue"
+      = @nsec

--- a/app/views/relays/_relay.html.slim
+++ b/app/views/relays/_relay.html.slim
@@ -2,7 +2,7 @@
 
 - if relay.first? && relay.enabled?
   - favorite = true
-- elsif Relay.enabled.by_position.first == relay
+- elsif Relay.main == relay
   - favorite = true
 
 details.border.mb-3.rounded-lg id=dom_id(relay) data-sortable-url=relay_path(relay) class=('opacity-50' unless relay.enabled?) class=(favorite ? 'border-green-300 bg-green-100' : 'border-gray-300 bg-gray-100')

--- a/app/views/stories/_story.html.slim
+++ b/app/views/stories/_story.html.slim
@@ -28,7 +28,12 @@
 
         .absolute.-bottom-4.-right-10
           - if story.nostr_user.profile.picture
-            = image_tag story.nostr_user.profile.picture, class: 'w-20 mx-auto mb-1 rounded-full border-2'
+            = image_tag polymorphic_path(story.nostr_user.picture),
+                        class: 'w-20 mx-auto mb-1 rounded-full border-2 bg-white',
+                        title: story.nostr_user.name
+          - else
+            .flex.items-center.justify-center.w-20.h-20.text-4xl.text-gray-100.mb-1.rounded-full.border-2.bg-gray-800 title=story.nostr_user.name
+              = story.nostr_user.initials
 
       p.text-sm.italic
         | Créé le

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,10 @@ module Fabelia
     config.time_zone = 'Europe/Paris'
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.i18n.available_locales = %i[fr en]
     config.i18n.default_locale = :fr
+    config.i18n.available_locales = %i[fr en]
+    config.i18n.enforce_available_locales = false
+    config.i18n.fallbacks = %i[en fr]
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
 
     config.active_record.encryption.primary_key = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY')

--- a/config/initializers/support.rb
+++ b/config/initializers/support.rb
@@ -1,4 +1,5 @@
 require 'retry'
+require 'nostr_override'
 
 %w[core_ext].each do |folder|
   Dir[Rails.root.join('lib', folder, '**', '*.rb')].each { |f| require f }

--- a/config/locales/actverecord.fr.yml
+++ b/config/locales/actverecord.fr.yml
@@ -20,9 +20,16 @@ fr:
 
       nostr_user:
         private_key: Clé privée
-        language: Language
+        language: Langage
         relays: Relays
         enabled: Activé ?
+        name: Nom
+        about: Description
+        nip05: NIP-05
+        website: Site internet
+        picture: Avatar
+        banner: Bannière
+        lud16: Adresse LN
 
       thematic:
         identifier: Identifiant

--- a/config/locales/nostr_user_errors.en.yml
+++ b/config/locales/nostr_user_errors.en.yml
@@ -4,3 +4,4 @@ en:
       bot_missing: "No bot exists to handle \"%{language}\" language, please configure one to publish"
       bot_disabled: "%{name} bot is disabled for \"%{language}\", you cannot published until you enabled it"
       missing_associated_relay: At least one relay is mandatory to publish note with this bot
+      empty_lightning_network_address: A LN address is mandatory to use poll adventures. You can configure one in the Nostr user options.

--- a/config/locales/nostr_user_errors.fr.yml
+++ b/config/locales/nostr_user_errors.fr.yml
@@ -4,3 +4,4 @@ fr:
       bot_missing: "Aucun bot n'existe pour gérer la langue \"%{language}\", veuillez en configurer un pour publier"
       bot_disabled: "%{name} bot est désactivé pour la langue \"%{language}\", vous ne pourrez pas publier avant de le réactiver"
       missing_associated_relay: Au moins un relais est requis pour publier une note avec ce bot
+      empty_lightning_network_address: Une adresse LN est requise pour utiliser les aventures sondages. Vous pouvez en configurer une dans les options du compte Nostr.

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -18,8 +18,16 @@ fr:
         private_key: La clé privée est chiffrée en base de données
         relays: Sélectionner le(s) relay(s) sur le(s)quel(s) publier les aventures ?
         enabled: Si coché, le compte Nostr sera autorisé à publier les aventures
+        lud16: Adresse Lightning Network pour recevoir des donations
+        nip05: Preuve de l'identité de la personne possédant le compte
 
       story:
         mode: Type d'aventure
         thematic: Thème de l'aventure
         nostr_user: Le compte Nostr de publication définit la langue de l'aventure
+
+    placeholders:
+      nostr_user:
+        nip05: name@domain.com
+        lud16: foo@getalby.com
+        website: https://mywebsite.com

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,15 @@ Rails.application.routes.draw do
     scope module: :nostr_users do
       member do
         resource :refresh_profiles, only: :create
+
+        resource :private_keys, only: [] do
+          get :ask_password
+          post :reveal
+        end
+      end
+
+      collection do
+        resource :import_profiles, only: %i[new create]
       end
     end
   end

--- a/db/migrate/20230828204725_add_metadata_inputs_to_nostr_users.rb
+++ b/db/migrate/20230828204725_add_metadata_inputs_to_nostr_users.rb
@@ -1,0 +1,10 @@
+class AddMetadataInputsToNostrUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :nostr_users, :mode, :integer, null: false, default: 0
+    add_column :nostr_users, :name, :string
+    add_column :nostr_users, :about, :text
+    add_column :nostr_users, :nip05, :string
+    add_column :nostr_users, :website, :string
+    add_column :nostr_users, :lud16, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_19_185604) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_28_204725) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_19_185604) do
     t.integer "stories_count", default: 0, null: false
     t.boolean "enabled", default: true, null: false
     t.json "metadata_response", default: {}, null: false
+    t.integer "mode", default: 0, null: false
+    t.string "name"
+    t.text "about"
+    t.string "nip05"
+    t.string "website"
+    t.string "lud16"
     t.index ["language"], name: "index_nostr_users_on_language", unique: true
     t.index ["private_key"], name: "index_nostr_users_on_private_key", unique: true
   end

--- a/lib/nostr_override.rb
+++ b/lib/nostr_override.rb
@@ -1,0 +1,43 @@
+# :nocov:
+# Override nostr-ruby gem methods
+class Nostr
+  def build_metadata_event(opts = {})
+    data = opts.slice(
+      :name, :about, :picture, :banner, :nip05, :lud16, :website
+    )
+
+    event = {
+      pubkey: @public_key,
+      created_at: Time.now.utc.to_i,
+      kind: 0,
+      tags: [],
+      content: data.to_json
+    }
+
+    build_event(event)
+  end
+
+  def test_post_event(event, relay)
+    response = nil
+    ws = WebSocket::Client::Simple.connect(relay)
+
+    ws.on :open do
+      ws.send event.to_json
+    end
+
+    ws.on :message do |msg|
+      response = JSON.parse(msg.data.force_encoding('UTF-8'))
+      ws.close
+    end
+
+    ws.on :error do |e|
+      debug_logger('WebSocket Error', e, :red)
+      ws.close
+    end
+
+    sleep 0.1 while response.nil?
+
+    response
+  end
+end
+# :nocov:

--- a/spec/factories/nostr_users.rb
+++ b/spec/factories/nostr_users.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :nostr_user do
-    sequence(:private_key) { Faker::Crypto.sha256 }
+    name { Faker::Name.name }
     language { I18nData.languages.keys.sample }
+    sequence(:private_key) { Faker::Crypto.sha256 }
 
     relays { create_list :relay, 3 }
   end

--- a/spec/requests/nostr_users/refresh_profiles_controller_spec.rb
+++ b/spec/requests/nostr_users/refresh_profiles_controller_spec.rb
@@ -4,11 +4,7 @@ RSpec.describe NostrUsers::RefreshProfilesController do
   describe 'POST /nostr_users/::id/refresh_profiles' do
     subject(:action) { post "/nostr_users/#{nostr_user.id}/refresh_profiles" }
 
-    let!(:nostr_user) { create :nostr_user }
-
-    before do
-      allow(NostrServices::FetchProfile).to receive(:call) { {} }
-    end
+    let(:nostr_user) { create :nostr_user }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -16,10 +12,14 @@ RSpec.describe NostrUsers::RefreshProfilesController do
     context 'when logged in with proper accreditation', as: :logged_in do
       let(:role) { :admin }
 
+      before do
+        allow(NostrAccounts::ImportProfile).to receive(:call) { {} }
+      end
+
       describe '[nostr service]' do
         before { action }
 
-        it { expect(NostrServices::FetchProfile).to have_received(:call).with(nostr_user) }
+        it { expect(NostrAccounts::ImportProfile).to have_received(:call).with(nostr_user) }
       end
 
       include_examples 'a redirect response with success message' do

--- a/spec/requests/nostr_users_controller_spec.rb
+++ b/spec/requests/nostr_users_controller_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe NostrUsersController do
-  before do
-    allow(NostrServices::FetchProfile).to receive(:call) { {} }
-  end
-
   describe 'GET /nostr_users' do
     subject(:action) { get '/nostr_users' }
 
@@ -60,11 +56,17 @@ RSpec.describe NostrUsersController do
 
     context 'when logged in with proper accreditation', as: :logged_in do
       let(:role) { :super_admin }
+      let(:instance) { instance_double(NostrAccounts::PublishProfile) }
+
+      before do
+        allow(NostrAccounts::PublishProfile).to receive(:new) { instance }
+        allow(instance).to receive(:build_and_publish_event)
+      end
 
       context 'when params are invalid' do
         let(:params) do
           attributes_for(:nostr_user)
-            .merge(relay_ids: [relay.id], private_key: nil)
+            .merge(relay_ids: [relay.id], name: nil)
         end
 
         before { action }
@@ -78,7 +80,7 @@ RSpec.describe NostrUsersController do
         end
 
         include_examples 'a redirect response with success message' do
-          let(:message) { 'Nostr user was successfully created.' }
+          let(:message) { "Votre compte Nostr vient d'être créé ! ⚠️ Assurez-vous d'avoir fait une sauvegarde de votre clé privée pour ne pas perdre votre compte ⚠️" }
           let(:url_to_redirect) { nostr_users_path }
         end
       end
@@ -117,9 +119,15 @@ RSpec.describe NostrUsersController do
 
     context 'when logged in with proper accreditation', as: :logged_in do
       let(:role) { :super_admin }
+      let(:instance) { instance_double(NostrAccounts::PublishProfile) }
+
+      before do
+        allow(NostrAccounts::PublishProfile).to receive(:new) { instance }
+        allow(instance).to receive(:build_and_publish_event)
+      end
 
       context 'when params are invalid' do
-        let(:params) { { private_key: nil } }
+        let(:params) { { name: nil } }
 
         before { action }
 


### PR DESCRIPTION
Add a new feature to create from Rails backend Nostr accounts and publish them to relays.

Details:
- Add a new form to generate Nostr account with private key
- Add migration to handle more metadata options (about, nip05, lud16, ...)
- Add an option to display private key in interface (require to enter password)
- Create a `nostr_override.rb` class to update some methods from `nostr_ruby` gem

Closes #52