### PR TITLE
Remove unique language index on `NostrUser`

### DIFF
--- a/app/models/nostr_user.rb
+++ b/app/models/nostr_user.rb
@@ -69,7 +69,7 @@ end
 #  stories_count     :integer          default(0), not null
 #  enabled           :boolean          default(TRUE), not null
 #  metadata_response :json             not null
-#  mode              :integer          default(0), not null
+#  mode              :integer          default("generated"), not null
 #  name              :string
 #  about             :text
 #  nip05             :string
@@ -78,6 +78,5 @@ end
 #
 # Indexes
 #
-#  index_nostr_users_on_language     (language) UNIQUE
 #  index_nostr_users_on_private_key  (private_key) UNIQUE
 #

--- a/db/migrate/20230903203935_remove_unique_index_on_nostr_user_language.rb
+++ b/db/migrate/20230903203935_remove_unique_index_on_nostr_user_language.rb
@@ -1,0 +1,9 @@
+class RemoveUniqueIndexOnNostrUserLanguage < ActiveRecord::Migration[7.0]
+  def up
+    remove_index :nostr_users, :language
+  end
+
+  def down
+    add_index :nostr_users, :language, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_28_204725) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_03_203935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,7 +78,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_204725) do
     t.string "nip05"
     t.string "website"
     t.string "lud16"
-    t.index ["language"], name: "index_nostr_users_on_language", unique: true
     t.index ["private_key"], name: "index_nostr_users_on_private_key", unique: true
   end
 
@@ -86,6 +85,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_204725) do
     t.bigint "nostr_user_id", null: false
     t.bigint "relay_id", null: false
     t.index ["nostr_user_id", "relay_id"], name: "index_nostr_users_relays_on_nostr_user_id_and_relay_id", unique: true
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name"
+    t.integer "users_count", default: 0, null: false
+    t.integer "thematics_count", default: 0, null: false
+    t.integer "nostr_users_count", default: 0, null: false
+    t.integer "relays_count", default: 0, null: false
+    t.integer "stories_count", default: 0, null: false
+    t.boolean "enabled", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "relays", force: :cascade do |t|

--- a/spec/models/nostr_user_spec.rb
+++ b/spec/models/nostr_user_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe NostrUser do
       it { is_expected.to validate_presence_of(:private_key).allow_blank }
       it { is_expected.to validate_presence_of(:relays) }
       it { is_expected.to validate_presence_of(:language) }
+      it { is_expected.to_not validate_uniqueness_of(:language) }
       it { is_expected.to allow_value(nil, '', 'foo@bar.com').for(:nip05) }
       it { is_expected.to_not allow_value('foobar', 'foobar.com').for(:nip05) }
       it { is_expected.to allow_value(nil, '', 'foo@bar.com').for(:lud16) }
@@ -24,6 +25,7 @@ RSpec.describe NostrUser do
       it { is_expected.to validate_presence_of(:private_key) }
       it { is_expected.to validate_presence_of(:relays) }
       it { is_expected.to validate_presence_of(:language) }
+      it { is_expected.to_not validate_uniqueness_of(:language) }
       it { is_expected.to allow_value(nil, '', 'foo@bar.com').for(:nip05) }
       it { is_expected.to_not allow_value('foobar', 'foobar.com').for(:nip05) }
       it { is_expected.to allow_value(nil, '', 'foo@bar.com').for(:lud16) }


### PR DESCRIPTION
Follows #59

Remove the PostgreSQL unique language index that is not meant to remain after #59 refactoring.  
A language can be used multiple time on multiple `NostrUser` records.