### PR TITLE
Handle default relays list

### DIFF
--- a/app/controllers/nostr_users_controller.rb
+++ b/app/controllers/nostr_users_controller.rb
@@ -77,6 +77,7 @@ class NostrUsersController < ApplicationController
   def nostr_user_params
     params.require(:nostr_user)
           .permit(:name, :about, :nip05, :lud16, :website,
-                  :picture, :banner, :language, :enabled)
+                  :picture, :banner, :language, :enabled,
+                  relay_ids: [])
   end
 end

--- a/app/controllers/relays/resets_controller.rb
+++ b/app/controllers/relays/resets_controller.rb
@@ -1,0 +1,12 @@
+module Relays
+  class ResetsController < ApplicationController
+    # @route POST /relays/resets (relays_resets)
+    def create
+      authorize! Relay, with: ResetListPolicy
+
+      Relay.reset!
+
+      redirect_to relays_path, notice: 'Les relays ont été réinitialisés'
+    end
+  end
+end

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -1,4 +1,16 @@
 class Relay < ApplicationRecord
+  DEFAULT_LIST = %w[
+    wss://no.str.cr
+    wss://relay.snort.social
+    wss://relay.damus.io
+    wss://nostr.bitcoiner.social
+    wss://relay.nostr.bg
+    wss://nostr.oxtr.dev
+    wss://nostr-pub.wellorder.net
+    wss://nostr.mom
+    wss://nos.lol
+  ].freeze
+
   has_many :nostr_users_relays, dependent: :destroy
   has_many :nostr_users, through: :nostr_users_relays
 
@@ -14,6 +26,16 @@ class Relay < ApplicationRecord
 
   def self.main
     enabled.by_position.first
+  end
+
+  def self.reset!
+    transaction do
+      Relay.delete_all
+
+      DEFAULT_LIST.each do |relay|
+        create!(url: relay)
+      end
+    end
   end
 
   # NOTE: title is used as alias to get correct form label association

--- a/app/views/relays/_relay.html.slim
+++ b/app/views/relays/_relay.html.slim
@@ -8,7 +8,7 @@
 details.border.mb-3.rounded-lg id=dom_id(relay) data-sortable-url=relay_path(relay) class=('opacity-50' unless relay.enabled?) class=(favorite ? 'border-green-300 bg-green-100' : 'border-gray-300 bg-gray-100')
   summary.flex.items-center.gap-3.justify-between.p-2.relative
     - if favorite
-      span.absolute.-top-3.-left-2 title="Relay favori" ⭐
+      span.absolute.-top-3.-left-2.cursor-help title="Relay favori" ⭐
     .flex.items-center.gap-3
       span.handle.cursor-move ↕️
       span.font-bold ##{relay.position}

--- a/app/views/relays/index.html.slim
+++ b/app/views/relays/index.html.slim
@@ -4,5 +4,17 @@ header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
   - if allowed_to?(:create?, Relay)
     = link_to 'Ajouter un relais', new_relay_path, class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-green-700 rounded-lg hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300'
 
+details.border.p-2.mb-5
+  summary.cursor-pointer.font-bold Relais par défaut
+
+  ul.list-disc.list-inside.mt-1.mb-3
+    - Relay::DEFAULT_LIST.each do |relay|
+      li= relay
+
+  = button_to 'Réinitialiser les relais',
+              relays_resets_path,
+              data: { turbo_confirm: 'Voulez-vous réinitialiser les relays ? ⚠️ Vous allez perdre toutes vos configurations actuelles avec vos comptes Nostr ⚠️' },
+              class: 'destroy-button'
+
 #relays data-controller="sortable" data-sortable-ghost-class="bg-gray-200" data-sortable-filter-class="opacity-25" data-sortable-model-value="relay"
   = render @relays

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,14 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :relays, except: :show
+  resources :relays, except: :show do
+    scope module: :relays do
+      collection do
+        resource :resets, only: :create, as: :relays_resets
+      end
+    end
+  end
+
   resources :thematics, except: :show
 
   resource :settings, only: %i[show edit update]


### PR DESCRIPTION
Adds an endpoint to reset relays to default list:

- wss://no.str.cr
- wss://relay.snort.social
- wss://relay.damus.io
- wss://nostr.bitcoiner.social
- wss://relay.nostr.bg
- wss://nostr.oxtr.dev
- wss://nostr-pub.wellorder.net
- wss://nostr.mom
- wss://nos.lol