### PR TITLE
Allow to manually select option for next chapter

### DIFF
--- a/app/controllers/stories/chapters_controller.rb
+++ b/app/controllers/stories/chapters_controller.rb
@@ -7,6 +7,18 @@ module Stories
     def create
       authorize! Chapter, context: { story: @story }
 
+      @last_chapter = @story.chapters.published.last
+
+      option_index = params[:option_index]
+      index = if option_index.present?
+        option_index
+      else
+        option_count = @last_chapter.options.count
+        rand(0..(option_count - 1))
+      end
+
+      @last_chapter.update(most_voted_option_index: index.to_i)
+
       GenerateDropperChapterJob.perform_later(@story, force_publish: true, force_ending: force_end_of_story?)
 
       respond_to do |format|

--- a/app/views/chapters/_chapter.html.slim
+++ b/app/views/chapters/_chapter.html.slim
@@ -12,8 +12,8 @@
       .h-2.5.bg-gray-700.rounded-full.w-12
 
 - else
-  details.cursor-pointer.mb-2.bg-gray-100.rounded-lg.transition-all class=('opacity-50 grayscale hover:opacity-100 hover:grayscale-0' unless chapter.published?) id=dom_id(chapter)
-    summary.flex.items-center.gap-3.justify-between.p-2
+  details.mb-2.bg-gray-100.rounded-lg.transition-all class=('opacity-50 grayscale hover:opacity-100 hover:grayscale-0' unless chapter.published?) id=dom_id(chapter)
+    summary.flex.items-center.gap-3.justify-between.p-2.cursor-pointer
       .flex.items-center.gap-3
         span.text-gray-600 ##{chapter.position}
 
@@ -67,8 +67,25 @@
 
         == chapter.content
 
-      - if chapter.options.any?
-        .grid.grid-cols-3.gap-3
-          - chapter.options.each do |option|
-            .border-2.border-blue-700.bg-blue-200.p-2.rounded-lg.flex.items-center
-              = option
+      - chapter.options.any?
+        .flex.items-center.gap-3
+          - if chapter.story.complete?
+            - chapter.options.each do |option, index|
+              .border-2.border-blue-700.bg-blue-200.p-2.rounded-lg.flex.items-center
+                = option
+
+          - else
+            - if chapter.published? && !chapter.last_to_publish?
+              - chapter.options.each_with_index do |option, index|
+                .relative.border-2.p-2.rounded-lg.flex.items-center.cursor-disabled class=(index == chapter.most_voted_option_index ? 'border-green-700 bg-green-200 hover:bg-green-300' : 'border-blue-700 bg-blue-200 hover:bg-blue-300')
+                  = option
+                  - if index == chapter.most_voted_option_index
+                    span.absolute.-top-3.-left-2.cursor-help.text-xl title="Choix" ⭐
+
+            - else
+              - chapter.options.each_with_index do |option, index|
+                = button_to option,
+                            story_chapters_path(chapter.story),
+                            data: { turbo_confirm: "Voulez-vous forcer la suite de l'aventure avec cette proposition ?" },
+                            params: { option_index: index },
+                            class: "flex items-center justify-center p-2 border-2 border-blue-700 bg-blue-200 rounded-lg transitions-colors cursor #{index == chapter.most_voted_option_index ? 'border-green-700 bg-green-200 hover:bg-green-300' : 'border-blue-700 bg-blue-200 hover:bg-blue-300' }"

--- a/app/views/homes/_stories.html.slim
+++ b/app/views/homes/_stories.html.slim
@@ -47,10 +47,9 @@ ul#quick_look role="list"
                             data: { turbo_method: :patch, turbo_confirm: "Voulez-vous générer une nouvelle couverture pour cette aventure ?" }
                 |.
 
-        .text-base.font-semibold.text-gray-900
-          - if story.nostr_user.profile.picture
-            = image_tag polymorphic_path(story.nostr_user.picture), class: 'w-24 mx-auto mb-1 rounded-full'
+        .text-base.font-semibold.text-gray-900.text-center
+          = image_tag story.nostr_user.picture_url, class: 'w-24 mx-auto mb-1 rounded-full'
 
-          p= story.nostr_user.profile.identity
-          p.inline-block.text-xs.font-medium.p-1.rounded.bg-blue-500.text-white.ml-2
+          p.text-sm.mb-1= story.nostr_user.profile.identity
+          p.inline-block.text-xs.font-medium.p-1.rounded.bg-blue-500.text-white
             = story.nostr_user.human_language

--- a/db/migrate/20230906124602_add_most_voted_option_index_to_chapter.rb
+++ b/db/migrate/20230906124602_add_most_voted_option_index_to_chapter.rb
@@ -1,0 +1,5 @@
+class AddMostVotedOptionIndexToChapter < ActiveRecord::Migration[7.0]
+  def change
+    add_column :chapters, :most_voted_option_index, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_04_163142) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_124602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_04_163142) do
     t.integer "position", default: 1, null: false
     t.boolean "publish", default: false, null: false
     t.integer "status", default: 0, null: false
+    t.integer "most_voted_option_index"
     t.index ["nostr_identifier"], name: "index_chapters_on_nostr_identifier", unique: true
     t.index ["replicate_identifier"], name: "index_chapters_on_replicate_identifier", unique: true
     t.index ["story_id"], name: "index_chapters_on_story_id"

--- a/spec/requests/stories/chapters_controller_spec.rb
+++ b/spec/requests/stories/chapters_controller_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Stories::ChaptersController do
     context 'when logged in with proper accreditation', as: :logged_in do
       let(:role) { :admin }
 
+      before do
+        create :chapter, :published, story: story
+      end
+
       context 'when adventure is forced to end' do
         let(:params) { { force_end: true } }
 


### PR DESCRIPTION
Fixes #71

Interface allows now to select one of option returned by ChatGPT to continue the adventure. It will be helpful waiting to figure out how to retrieve dynamically the voted option.

<img width="738" alt="Capture d’écran 2023-09-07 à 16 43 32" src="https://github.com/La-Voix-du-chat-artiste/fabelia/assets/5428510/759ac767-1e99-4d25-acd2-ca42e48d7f50">
