### PR TITLE
Extend story creation with advanced mode

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,5 +1,12 @@
 class StoriesController < ApplicationController
-  before_action :set_story, only: %i[update destroy]
+  before_action :set_story, only: %i[show update destroy]
+
+  # @route GET /stories/new (new_story)
+  def new
+    authorize! Story
+
+    @story = Story.new
+  end
 
   # @route POST /stories (stories)
   def create
@@ -21,11 +28,17 @@ class StoriesController < ApplicationController
 
       respond_to do |format|
         format.html { redirect_to root_path, notice: notice }
-        format.turbo_stream { flash.now[:notice] = notice }
       end
     else
-      redirect_to root_path, alert: @story.errors.full_messages.join(', ')
+      respond_to do |format|
+        format.html { render :new, status: :unprocessable_entity }
+      end
     end
+  end
+
+  # @route GET /stories/:id (story)
+  def show
+    authorize! @story
   end
 
   # @route PATCH /stories/:id (story)
@@ -65,7 +78,16 @@ class StoriesController < ApplicationController
 
   def story_params
     params.require(:story)
-          .permit(:nostr_user_id, :mode, :thematic_id, :publication_rule)
+          .permit(
+            :nostr_user_id, :mode, :thematic_id, :publication_rule,
+            options: %i[
+              minimum_chapters_count maximum_chapters_count
+              minimum_poll_sats maximum_poll_sats
+              stable_diffusion_prompt publish_previous
+              chatgpt_full_story_system_prompt
+              chatgpt_dropper_story_system_prompt
+            ]
+          )
   end
 
   def mode

--- a/app/javascript/controllers/quick_stories_controller.js
+++ b/app/javascript/controllers/quick_stories_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect() {
+    this.cookieName = 'hide_quick_story'
+
+    if(this._getCookie(this.cookieName)) {
+      this.element.removeAttribute('open')
+    }
+  }
+
+  setCookie() {
+    if(this._getCookie(this.cookieName)) {
+      // Delete the cookie
+      document.cookie = `${this.cookieName}=true; max-age=0;`;
+    } else {
+      // Set the cookie
+      document.cookie = `${this.cookieName}=true;`
+    }
+  }
+
+  _getCookie (name) {
+    let value = `; ${document.cookie}`
+    let parts = value.split(`; ${name}=`)
+
+    if (parts.length === 2) {
+      return parts.pop().split(';').shift()
+    }
+  }
+}

--- a/app/jobs/generate_story_job.rb
+++ b/app/jobs/generate_story_job.rb
@@ -33,11 +33,11 @@ class GenerateStoryJob < ApplicationJob
 
     Retry.on(*retryable_ai_errors) do
       if draft_story.complete?
-        @json = ChatGPTCompleteService.call(prompt, nostr_user.language)
+        @json = ChatGPTCompleteService.call(prompt, nostr_user.language, draft_story)
 
         raise ChapterErrors::FullStoryMissingChapters if @json['chapters'].count < 3
       else
-        @json = ChatGPTDropperService.call(prompt, nostr_user.language)
+        @json = ChatGPTDropperService.call(prompt, nostr_user.language, draft_story)
       end
     end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -2,6 +2,8 @@ class Story < ApplicationRecord
   include Coverable
   include NSFWCoverable
 
+  attribute :options, Setting::ChapterOption.to_type
+
   enum mode: { complete: 0, dropper: 1 }, _default: :complete
   enum status: { draft: 0, completed: 1 }, _default: :draft
   enum publication_rule: {
@@ -41,6 +43,7 @@ class Story < ApplicationRecord
 
   validates :mode, presence: true, inclusion: { in: modes.keys }
   validates :publication_rule, presence: true, inclusion: { in: publication_rules.keys }
+  validates :options, store_model: { merge_errors: true }
 
   scope :currents, -> { where(adventure_ended_at: nil) }
   scope :ended, -> { where.not(adventure_ended_at: nil) }
@@ -186,7 +189,7 @@ end
 #  raw_response_body           :json             not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  mode                        :integer          default("complete"), not null
+#  mode                        :integer          default(0), not null
 #  replicate_identifier        :string
 #  replicate_raw_request_body  :json             not null
 #  replicate_raw_response_body :json             not null
@@ -196,8 +199,9 @@ end
 #  nostr_user_id               :bigint(8)
 #  summary                     :string
 #  back_cover_nostr_identifier :string
-#  status                      :integer          default("draft"), not null
-#  publication_rule            :integer          default("do_not_publish"), not null
+#  publication_rule            :integer          default(0), not null
+#  status                      :integer          default(0), not null
+#  options                     :jsonb            not null
 #
 # Indexes
 #

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -1,7 +1,15 @@
 class StoryPolicy < ApplicationPolicy
   pre_check :allow_admins
 
+  def new?
+    true
+  end
+
   def create?
+    true
+  end
+
+  def show?
     true
   end
 

--- a/app/services/chatgpt_complete_service.rb
+++ b/app/services/chatgpt_complete_service.rb
@@ -1,9 +1,10 @@
 class ChatGPTCompleteService < ChatGPTService
-  attr_reader :prompt, :language, :model
+  attr_reader :prompt, :language, :story, :model
 
-  def initialize(prompt, language, model = 'gpt-3.5-turbo')
+  def initialize(prompt, language, story, model = 'gpt-3.5-turbo')
     @prompt = prompt
     @language = language
+    @story = story
     @model = model
   end
 

--- a/app/services/chatgpt_dropper_service.rb
+++ b/app/services/chatgpt_dropper_service.rb
@@ -1,7 +1,7 @@
 class ChatGPTDropperService < ChatGPTService
   attr_reader :prompt, :language, :story, :model
 
-  def initialize(prompt, language, story = nil, model = 'gpt-3.5-turbo')
+  def initialize(prompt, language, story, model = 'gpt-3.5-turbo')
     @prompt = prompt
     @language = language
     @story = story

--- a/app/services/chatgpt_service.rb
+++ b/app/services/chatgpt_service.rb
@@ -20,7 +20,7 @@ class ChatGPTService < ApplicationService
   end
 
   def chapter_options
-    @chapter_options ||= Setting.first.chapter_options
+    @chapter_options ||= story.options
   end
 
   def language_name

--- a/app/services/nostr_event.rb
+++ b/app/services/nostr_event.rb
@@ -30,6 +30,6 @@ class NostrEvent < ApplicationService
   end
 
   def options
-    @options ||= Setting.first.chapter_options
+    @options ||= story.options
   end
 end

--- a/app/services/replicate_services/picture.rb
+++ b/app/services/replicate_services/picture.rb
@@ -34,5 +34,9 @@ module ReplicateServices
 
       replicate_webhook_url(host: host, model: model.class.to_s)
     end
+
+    def default_keywords
+      model.is_a?(Story) ? story.options : chapter.story.options
+    end
   end
 end

--- a/app/views/homes/show.html.slim
+++ b/app/views/homes/show.html.slim
@@ -7,9 +7,9 @@
   = turbo_stream_from %i[stories current]
 
 - if allowed_to?(:create?, Story) && !display_ended?
-  details.bg-gray-200.mb-6.border.border-primary-color.rounded-lg open="open"
+  details.bg-gray-200.mb-6.border.border-primary-color.rounded-lg open="open" data-controller="quick-stories" data-action="click->quick-stories#setCookie"
     summary.bg-primary-color.text-white.p-2.cursor-pointer.rounded-lg Générateur d'aventures
-    = render 'quick_custom_story_generator', stories: @active_stories
+    = render 'stories/form_light', stories: @active_stories
 
 header.flex.flex-col.lg:flex-row.justify-between.items-center.mb-8
   h1.text-3xl
@@ -48,6 +48,8 @@ header.flex.flex-col.lg:flex-row.justify-between.items-center.mb-8
 
 #empty_stories
   = render 'empty_stories' if @stories.empty?
+
+= turbo_frame_tag :story_details
 
 - if @chapter_popup && allowed_to?(:show?, @chapter_popup, with: Stories::ChapterPolicy, context: { story: @chapter_popup.story })
   = turbo_frame_tag :chapter_details, src: story_chapter_path(@chapter_popup.story, @chapter_popup, format: :turbo_stream)

--- a/app/views/stories/_details.html.slim
+++ b/app/views/stories/_details.html.slim
@@ -1,0 +1,56 @@
+= turbo_frame_tag :story_details do
+  .fixed.bg-gray-600/75.inset-0.w-screen.h-screen.z-40
+    .max-h-full.max-w-4xl.mx-auto.overflow-x-hidden.overflow-y-auto.z-50.pb-16 class="h-[calc(100%-0rem)]" tabindex="-1" aria-modal="true" role="dialog" data-controller="modal"
+      .flex.items-center.justify-center.gap-3 data-modal-target="content"
+        / Modal content
+        .relative.bg-white.rounded-lg.shadow.w-full
+          / Modal header
+          .p-4.border-b.rounded-t
+            .flex.justify-between.gap-2.bg-gray-100.rounded-lg.p-2
+              .flex.gap-2
+                - if story.cover.attached?
+                  = image_tag polymorphic_path(story.cover.variant(:small)), class: 'rounded-lg w-28 h-28'
+
+                .text-gray-500
+                  h2.text-lg.font-semibold= story.title
+                  p.text-sm
+                    = story.human_mode
+                    |< de <strong>#{story.chapters_count}</strong> chapitres
+
+                  .flex.items-center.justify-start.gap-1.mt-2.bg-gray-200.p-1.rounded-lg
+                    - if story.nostr_user.profile.picture
+                      = image_tag polymorphic_path(story.nostr_user.picture),
+                                  class: 'w-12 rounded-full border-2 bg-white',
+                                  title: story.nostr_user.display_name
+                    - else
+                      .flex.items-center.justify-center.w-12.h-12.text-4xl.text-gray-100.rounded-full.border-2.bg-gray-800 title=story.nostr_user.display_name
+                        = story.nostr_user.initials
+
+                    div
+                      p.text-sm.text-gray-600= story.nostr_user.display_name
+                      p.text-xs.text-gray-400= "@#{story.nostr_user.name}"
+
+
+              <button type="button" class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center" data-action="click->modal#close">
+                <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+                </svg>
+                <span class="sr-only">Close modal</span>
+              </button>
+
+
+          .p-4.space-y-4
+            div
+              p.text-xs.italic
+                | Créé le
+                =< l(story.created_at)
+              p.text-xs.italic
+                | Mis à jour le
+                =< l(story.updated_at)
+
+            .material-theme== highlight_code(story.options.to_json)
+
+          = render 'turbo_confirm'
+
+css:
+  #{Pygments.css('.material-theme', style: :material)}

--- a/app/views/stories/_form.html.slim
+++ b/app/views/stories/_form.html.slim
@@ -1,12 +1,6 @@
-= simple_form_for Story.new,
-                  url: stories_path,
+= simple_form_for @story,
                   html: { \
-                    class: 'flex flex-col items-center gap-6 justify-between p-4 bg-gray-200 rounded-b-lg', \
-                    data: { \
-                      controller: 'jumpto', \
-                      action: 'turbo:submit-end->jumpto#jump', \
-                      jumpto_div_id_value: 'stories' \
-                    } \
+                    class: 'flex flex-col items-center gap-6 justify-between' \
                   } do |f|
 
   .flex.flex-col.lg:flex-row.gap-3.justify-between
@@ -37,6 +31,29 @@
               label_html: { class: 'block italic mb-2' },
               input_html: { class: 'w-full' },
               wrapper_html: { class: 'text-center w-full' }
+
+  div
+    = f.simple_fields_for :options, f.object.options do |ff|
+      .flex.flex-col.gap-6
+        .grid.grid-cols-1.lg:grid-cols-4.gap-3
+          = ff.input :minimum_chapters_count
+          = ff.input :maximum_chapters_count
+          = ff.input :minimum_poll_sats
+          = ff.input :maximum_poll_sats
+
+        = ff.input :publish_previous
+        = ff.input :stable_diffusion_prompt
+
+        .flex.justify-between.gap-6
+          = ff.input :chatgpt_full_story_system_prompt,
+                     as: :text,
+                     input_html: { class: 'h-72' },
+                     wrapper_html: { class: 'w-full' }
+
+          = ff.input :chatgpt_dropper_story_system_prompt,
+                     as: :text,
+                     input_html: { class: 'h-72' },
+                     wrapper_html: { class: 'w-full' }
 
   = f.button :submit, 'Créer une aventure sur mesure',
              class: 'bg-green-600 p-2 rounded-lg text-white cursor-pointer hover:bg-green-500 transition-colors'

--- a/app/views/stories/_form_light.html.slim
+++ b/app/views/stories/_form_light.html.slim
@@ -1,0 +1,50 @@
+= simple_form_for Story.new,
+                  url: stories_path,
+                  html: { \
+                    class: 'flex flex-col items-center gap-6 justify-between p-4 bg-gray-200 rounded-b-lg', \
+                    data: { \
+                      controller: 'jumpto', \
+                      action: 'turbo:submit-end->jumpto#jump', \
+                      jumpto_div_id_value: 'stories' \
+                    } \
+                  } do |f|
+
+  .flex.flex-col.lg:flex-row.gap-3.justify-between
+    = f.association :thematic,
+                    collection: Thematic.enabled,
+                    include_blank: '[Aléatoire]',
+                    label_html: { class: 'block italic mb-2' },
+                    input_html: { class: 'w-full' },
+                    wrapper_html: { class: 'text-center w-full' }
+
+    = f.input :mode,
+              collection: select_options_for(Story, :modes),
+              include_blank: false,
+              label_html: { class: 'block italic mb-2' },
+              input_html: { class: 'w-full' },
+              wrapper_html: { class: 'text-center w-full' }
+
+    = f.association :nostr_user,
+                    collection: story_nostr_users_select_options,
+                    include_blank: false,
+                    label_html: { class: 'block italic mb-2' },
+                    input_html: { class: 'w-full' },
+                    wrapper_html: { class: 'text-center w-full' }
+
+    = f.input :publication_rule,
+              collection: select_options_for(Story, :publication_rules),
+              include_blank: false,
+              label_html: { class: 'block italic mb-2' },
+              input_html: { class: 'w-full' },
+              wrapper_html: { class: 'text-center w-full' }
+
+  .flex.flex-col.items-center.justify-center.gap-3
+    = f.button :submit, 'Créer une aventure rapide',
+               class: 'bg-green-600 p-2 rounded-lg text-white cursor-pointer hover:bg-green-500 transition-colors'
+
+    p
+      | ou
+
+      =< link_to 'Créer une aventure sur mesure',
+                 new_story_path,
+                 class: 'underline'

--- a/app/views/stories/_story.html.slim
+++ b/app/views/stories/_story.html.slim
@@ -42,6 +42,11 @@
         | Mis à jour le
         =< l(story.updated_at)
 
+      = link_to 'Détails', story_path(story),
+                class: 'text-xs underline',
+                id: dom_id(story),
+                data: { turbo_stream: true }
+
     .w-full.lg:w-3/5.p-3.bg-stone-700.rounded-r-lg.lg:overflow-y-auto
       div id=dom_id(story, :chapters)
         = render story.chapters.with_attached_cover.order(id: :asc)

--- a/app/views/stories/chapters/_cover_placeholder.html.slim
+++ b/app/views/stories/chapters/_cover_placeholder.html.slim
@@ -1,0 +1,3 @@
+.flex.items-center.justify-center.w-full.h-72.bg-gray-300.rounded.animate-pulse.mb-3
+  svg.w-10.h-10.text-gray-600 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18"
+    path d="M18 0H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2Zm-5.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3Zm4.376 10.481A1 1 0 0 1 16 15H4a1 1 0 0 1-.895-1.447l3.5-7A1 1 0 0 1 7.468 6a.965.965 0 0 1 .9.5l2.775 4.757 1.546-1.887a1 1 0 0 1 1.618.1l2.541 4a1 1 0 0 1 .028 1.011Z"

--- a/app/views/stories/new.html.slim
+++ b/app/views/stories/new.html.slim
@@ -1,0 +1,6 @@
+header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
+  h1.text-3xl Création avancée d'une aventure
+
+  = link_to '<< Retour', root_path, class: 'back-link'
+
+= render 'form', story: @story

--- a/app/views/stories/show.turbo_stream.slim
+++ b/app/views/stories/show.turbo_stream.slim
@@ -1,0 +1,4 @@
+= render_turbo_stream_flash_messages
+
+= turbo_stream.replace :story_details do
+  = render 'details', story: @story

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -12,6 +12,15 @@ fr:
       story:
         publication_rule: Règles de publication
         nostr_user_id: Compte Nostr
+        options:
+          minimum_chapters_count: Nombre de chapitres minimum
+          maximum_chapters_count: Nombre de chapitres maximum
+          minimum_poll_sats: Nombre minimum de sats pour voter
+          maximum_poll_sats: Nombre maximum de sats pour voter
+          publish_previous: Publier le chapitre précédent ?
+          chatgpt_full_story_system_prompt: Prompt ChatGPT pour les aventures complètes
+          chatgpt_dropper_story_system_prompt: Prompt ChatGPT pour les aventures avec votes
+          stable_diffusion_prompt: Prompt pour StableDiffusion
 
     hints:
       nostr_user:
@@ -28,6 +37,8 @@ fr:
         mode: Type d'aventure
         thematic: Thème de l'aventure
         nostr_user: Le compte Nostr de publication définit la langue de l'aventure
+        options:
+          publish_previous: Si coché, le chapitre précédent le chapitre courant sera publié s'il ne l'a pas encore été
 
     placeholders:
       nostr_user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resource :sessions, only: %i[new create destroy]
   resources :password_resets, only: %i[new create edit update]
 
-  resources :stories, only: %i[create update destroy] do
+  resources :stories, only: %i[new create show update destroy] do
     scope module: :stories do
       resource :covers, only: %i[update]
 

--- a/db/migrate/20230910171947_add_options_to_story.rb
+++ b/db/migrate/20230910171947_add_options_to_story.rb
@@ -1,0 +1,5 @@
+class AddOptionsToStory < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stories, :options, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_124602) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_10_171947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -124,6 +124,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_124602) do
     t.string "back_cover_nostr_identifier"
     t.integer "publication_rule", default: 0, null: false
     t.integer "status", default: 0, null: false
+    t.jsonb "options", default: {}, null: false
     t.index ["back_cover_nostr_identifier"], name: "index_stories_on_back_cover_nostr_identifier", unique: true
     t.index ["nostr_identifier"], name: "index_stories_on_nostr_identifier", unique: true
     t.index ["nostr_user_id"], name: "index_stories_on_nostr_user_id"


### PR DESCRIPTION
Fixes #70

Add a new `new` action with extended form input to create more advanced stories.  
With this new form it is now possible to override global settings per stories scope.

Details:
- Add new migration to store `options` at story level
- Add new `stories#show` routes to display as modal the story details
- Store as JS cookies if quick story generator `<details>` tag should be opened or closed

<img width="1258" alt="Capture d’écran 2023-09-11 à 11 00 41" src="https://github.com/La-Voix-du-chat-artiste/fabelia/assets/5428510/3957f483-8617-40d5-ab74-da8883c8c744">
