### PR TITLE
Hide sats fields on story form for complete stories

### DIFF
--- a/app/javascript/controllers/slim_select_controller.js
+++ b/app/javascript/controllers/slim_select_controller.js
@@ -23,19 +23,33 @@ export default class extends Controller {
   }
 
   // Specific action used in story form
-  togglePromptSystem(e) {
+  toggleStoryFormFields(e) {
     e.preventDefault()
 
     const selected = e.target.value
     const $completeText = document.getElementById('extra_complete_text')
     const $dropperText = document.getElementById('extra_dropper_text')
 
+    const $storyOptionsMinimumPollSats = document.querySelector('.story_options_minimum_poll_sats')
+    const $storyOptionsMaximumPollSats = document.querySelector('.story_options_maximum_poll_sats')
+
     if (selected == 'dropper') {
       $completeText.classList.add('hidden')
       $dropperText.classList.remove('hidden')
+
+      $storyOptionsMinimumPollSats.classList.remove('hidden')
+      $storyOptionsMaximumPollSats.classList.remove('hidden')
+      $storyOptionsMinimumPollSats.setAttribute('disabled', false)
+      $storyOptionsMaximumPollSats.setAttribute('disabled', false)
+
     } else if (selected == 'complete') {
       $completeText.classList.remove('hidden')
       $dropperText.classList.add('hidden')
+
+      $storyOptionsMinimumPollSats.classList.add('hidden')
+      $storyOptionsMaximumPollSats.classList.add('hidden')
+      $storyOptionsMinimumPollSats.setAttribute('disabled', true)
+      $storyOptionsMaximumPollSats.setAttribute('disabled', true)
     }
   }
 }

--- a/app/views/stories/_form.html.slim
+++ b/app/views/stories/_form.html.slim
@@ -35,7 +35,7 @@ details.panel-info.mb-5
                 data: { \
                   controller: 'slim-select', \
                   slim_select_show_search_value: false, \
-                  action: 'change->slim-select#togglePromptSystem' \
+                  action: 'change->slim-select#toggleStoryFormFields' \
                 } \
               }, \
               wrapper_html: { class: 'text-center w-full' }
@@ -98,11 +98,11 @@ details.panel-info.mb-5
         section.mb-5
           p.text-xl.font-semibold.mb-3.border-b.dark:border-gray-600.dark:text-gray-600 Options
 
-          .grid.grid-cols-1.lg:grid-cols-4.gap-3.mb-5
-            = ff.input :minimum_chapters_count
-            = ff.input :maximum_chapters_count
-            = ff.input :minimum_poll_sats
-            = ff.input :maximum_poll_sats
+          .flex.flex-col.lg:flex-row.items-center.gap-3.mb-3
+            = ff.input :minimum_chapters_count, wrapper_html: { class: 'w-full' }
+            = ff.input :maximum_chapters_count, wrapper_html: { class: 'w-full' }
+            = ff.input :minimum_poll_sats, wrapper_html: { class: 'w-full hidden' }
+            = ff.input :maximum_poll_sats, wrapper_html: { class: 'w-full hidden' }
 
           = ff.input :publish_previous
 


### PR DESCRIPTION
Pregenerated stories does not require an amount of satoshis as user is not involved in the narration.  
For these, the two fields (minimum and maximum amount) should be hidden in the form.