### PR TITLE
Add `brakeman` code analyzer

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -1,15 +1,30 @@
 name: "Ruby on Rails CI"
+
 on:
   push:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+
 jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - name: Scan for security vulnerabilities
+        run: bin/brakeman
+
   test:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11-alpine
+        image: postgres:14-alpine
         ports:
           - "5432:5432"
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 
 group :development do
   gem 'annotate'
+  gem 'brakeman', require: false
   gem 'bullet'
   gem 'chusaku', require: false
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       ecdsa (~> 1.2.0)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
+    brakeman (6.1.1)
+      racc
     builder (3.2.4)
     bullet (7.1.4)
       activesupport (>= 3.0.0)
@@ -441,6 +443,7 @@ DEPENDENCIES
   acts_as_list
   annotate
   bootsnap
+  brakeman
   bullet
   chusaku
   debug

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -16,18 +16,19 @@ class PromptsController < ApplicationController
   def new
     authorize! Prompt
 
-    if params[:type].blank?
+    begin
+      type = Base64.decode64(params[:type])
+    rescue StandardError
+      type = nil
+    end
+
+    allowed_types = %w[NarratorPrompt MediaPrompt AtmospherePrompt]
+
+    if params[:type].present? && allowed_types.include?(type)
+      @prompt = type.constantize.new
+    else
       type = Base64.encode64('NarratorPrompt')
       redirect_to new_prompt_path(type: type)
-    else
-      type = Base64.decode64(params[:type])
-
-      begin
-        @prompt = type.constantize.new
-      rescue StandardError
-        type = Base64.encode64('NarratorPrompt')
-        redirect_to new_prompt_path(type: type)
-      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  EMAIL_REGEX = /\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+/
+  EMAIL_REGEX = /\A[^@\s]+@([^@.\s]+\.)+[^@.\s]+\z/
 
   enum role: { standard: 0, admin: 1, super_admin: 2 }
 

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
Brakeman is a gem that analyzes vulnerabilities on Rails projects. It will be provided out of the box by Rails 8 so it is a good idea to add it to the project.

Details:
- Add `brakeman` gem and binstub
- Run `brakeman` process on Github Actions CI
- Fix vulnerability on user email regexp
- Fix vulnerability on constantize class from params
- Upgrade Postgres database version on CI to reflect development one