### PR TITLE
Generate stories as PDF

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 # Rails
 PORT=PORT
+BASE_URL=BASE_URL
 SECRET_KEY_BASE=SECRET_KEY_BASE
 
 # Database encrpytion

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'turbo_power'
 gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'whenever', require: false
+gem 'wicked_pdf'
+gem 'wkhtmltopdf-binary'
 
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,6 +432,9 @@ GEM
     websocket-extensions (0.1.5)
     whenever (1.0.0)
       chronic (>= 0.6.3)
+    wicked_pdf (2.7.0)
+      activesupport
+    wkhtmltopdf-binary (0.12.6.6)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -489,6 +492,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
   whenever
+  wicked_pdf
+  wkhtmltopdf-binary
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/app/controllers/public/stories_controller.rb
+++ b/app/controllers/public/stories_controller.rb
@@ -1,0 +1,34 @@
+module Public
+  class StoriesController < ApplicationController
+    skip_before_action :require_login
+
+    before_action :set_story
+
+    # @route GET /p/s/:id (public_story)
+    def show
+      authorize! @story
+
+      respond_to do |format|
+        format.pdf { render pdf: @story.title }
+      end
+    end
+
+    private
+
+    def set_story
+      @story = Story.find(id)
+    end
+
+    # TODO: Use `uuid` as primary key for stories
+    def id
+      Base64.strict_decode64(params[:id])
+    end
+
+    def unauthorized_access(e)
+      policy_name = e.policy.to_s.underscore
+      message = t "#{policy_name}.#{e.rule}", scope: 'action_policy', default: :default
+
+      redirect_to new_sessions_path, alert: message
+    end
+  end
+end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -94,6 +94,7 @@ class StoriesController < ApplicationController
               publish_previous
               chatgpt_full_story_system_prompt
               chatgpt_dropper_story_system_prompt
+              read_as_pdf
             ]
           )
   end

--- a/app/models/story_option.rb
+++ b/app/models/story_option.rb
@@ -3,4 +3,5 @@ class StoryOption < Option
   attribute :chatgpt_dropper_story_system_prompt, :string
   attribute :stable_diffusion_prompt, :string
   attribute :stable_diffusion_negative_prompt, :string
+  attribute :read_as_pdf, :boolean, default: true
 end

--- a/app/policies/public/story_policy.rb
+++ b/app/policies/public/story_policy.rb
@@ -1,0 +1,17 @@
+module Public
+  class StoryPolicy < ApplicationPolicy
+    authorize :user, allow_nil: true
+
+    def show?
+      return true if user && admin_up?
+
+      story.options.read_as_pdf? && story.ended?
+    end
+
+    private
+
+    def story
+      record
+    end
+  end
+end

--- a/app/services/base_replicate.rb
+++ b/app/services/base_replicate.rb
@@ -12,6 +12,8 @@ class BaseReplicate < ApplicationService
   end
 
   def host
-    Rails.application.config.action_controller.default_url_options[:host]
+    return ENV.fetch('HOST', nil) if Rails.env.development?
+
+    ENV.fetch('BASE_URL')
   end
 end

--- a/app/services/nostr_builder/profile_metadata_event.rb
+++ b/app/services/nostr_builder/profile_metadata_event.rb
@@ -26,13 +26,19 @@ module NostrBuilder
     def picture
       return unless nostr_user.picture.attached?
 
-      polymorphic_url(nostr_user.picture, port: nil, host: ENV.fetch('HOST', nil))
+      polymorphic_url(nostr_user.picture, port: nil, host: host)
     end
 
     def banner
       return unless nostr_user.banner.attached?
 
-      polymorphic_url(nostr_user.banner, port: nil, host: ENV.fetch('HOST', nil))
+      polymorphic_url(nostr_user.banner, port: nil, host: host)
+    end
+
+    def host
+      return ENV.fetch('HOST', nil) if Rails.env.development?
+
+      ENV.fetch('BASE_URL')
     end
   end
 end

--- a/app/services/nostr_publisher/back_cover.rb
+++ b/app/services/nostr_publisher/back_cover.rb
@@ -1,5 +1,7 @@
 module NostrPublisher
   class BackCover < ApplicationService
+    include Rails.application.routes.url_helpers
+
     attr_reader :chapter
 
     def initialize(chapter)
@@ -17,13 +19,34 @@ module NostrPublisher
     private
 
     def body
-      <<~BACKCOVER
+      return main_body unless options.read_as_pdf?
+
+      pdf_url = public_story_url(
+        Base64.strict_encode64("#{story.id}-#{story.title}"),
+        format: :pdf
+      )
+
+      main_body_with_pdf_url(pdf_url)
+    end
+
+    def main_body
+      <<~BODY
         🔥 📖 🤖
 
         #{I18n.t('chapters.back_cover.content')}
 
         https://flownaely.cafe
-      BACKCOVER
+      BODY
+    end
+
+    def main_body_with_pdf_url(pdf_url)
+      <<~BODY
+        🔥 📖 🤖
+
+        #{I18n.t('chapters.back_cover.content_with_pdf_url', public_pdf_url: pdf_url)}
+
+        https://flownaely.cafe
+      BODY
     end
 
     def nostr_user
@@ -32,6 +55,14 @@ module NostrPublisher
 
     def reference
       chapter.nostr_identifier
+    end
+
+    def story
+      chapter.story
+    end
+
+    def options
+      story.options
     end
   end
 end

--- a/app/services/replicate_services/picture.rb
+++ b/app/services/replicate_services/picture.rb
@@ -33,9 +33,9 @@ module ReplicateServices
     private
 
     def webhook_url
-      return replicate_webhook_publish_url(host: host, model: model.class.to_s) if publish
+      return replicate_webhook_publish_url(host: host, port: nil, model: model.class.to_s) if publish
 
-      replicate_webhook_url(host: host, model: model.class.to_s)
+      replicate_webhook_url(host: host, port: nil, model: model.class.to_s)
     end
 
     def story

--- a/app/views/layouts/application.pdf.slim
+++ b/app/views/layouts/application.pdf.slim
@@ -1,0 +1,6 @@
+html
+  head
+    = wicked_pdf_stylesheet_link_tag 'tailwind'
+
+  body.prose
+    = yield

--- a/app/views/public/stories/show.pdf.slim
+++ b/app/views/public/stories/show.pdf.slim
@@ -1,0 +1,62 @@
+/ Front
+
+- if @story.cover.attached?
+  = image_tag polymorphic_url(@story.cover), class: 'block mx-auto object-cover max-h-[500px] mb-6 border-4'
+
+h1.text-center.text-5xl.font-bold= @story.title
+
+hr.border-2.my-6
+
+/ .mb-3= @story.narrator_prompt.title
+/ .mb-3= @story.atmosphere_prompt.title
+
+- if @story.characters.any?
+  - @story.characters.each do |character|
+    .flex.items-center.mb-3
+      = image_tag polymorphic_url(character.avatar), class: 'w-20 h-20 rounded-full object-cover border border-gray-700'
+
+      p.text-sm.ml-3= character.name
+
+
+- if @story.places.any?
+  - @story.places.each do |place|
+    .flex.items-center.mb-3
+      = image_tag polymorphic_url(place.photo), class: 'w-20 h-20 rounded-full object-cover border border-gray-700'
+
+      p.text-sm.ml-3= place.name
+
+
+/ Chapters
+
+- @story.chapters.by_position.each do |chapter|
+  .page-break
+
+  h2.text-center.text-2xl.font-bold.mb-6
+    = chapter.title
+
+  - if chapter.cover.attached?
+    = image_tag polymorphic_url(chapter.cover), class: 'block mx-auto object-cover max-h-[300px] mb-6 border-4'
+
+  .border.p-3
+    == chapter.content
+
+
+/ Back
+
+.page-break
+
+h2.text-center.text-xl.font-bold.mb-6 Fin de l'histoire !
+
+- if @story.cover.attached?
+  = image_tag polymorphic_url(@story.cover), class: 'block mx-auto object-cover max-h-[200px] mb-12 border-4'
+
+.border.p-3
+  .mb-6== simple_format t('chapters.back_cover.content')
+
+  p.text-center.text-3xl
+    = link_to 'Lire sur Nostr', "https://njump.me/#{@story.chapters.first.nostr_identifier}"
+
+css:
+  .page-break { display: block; clear: both; page-break-after: always; }
+  .flex { display: -webkit-box; }
+  .items-center { -webkit-box-align : center; }

--- a/app/views/stories/_details.html.slim
+++ b/app/views/stories/_details.html.slim
@@ -112,16 +112,14 @@
 
     / Modal footer
     footer.pt-4.mt-4.border-t.border-gray-200.dark:border-gray-600
-      .flex.flex-col.lg:flex-row.items-center.justify-between.gap-3
-        .text-center
-          p.text-xs.italic
-            | Créé le
-            =< l(story.created_at)
-          p.text-xs.italic
-            | Mis à jour le
-            =< l(story.updated_at)
-
+      .flex.flex-col.items-center.justify-between.gap-3
         .flex.items-center.gap-3
+          - if allowed_to?(:show?, @story, namespace: Public)
+            = link_to 'Lire en PDF',
+                      public_story_path(Base64.strict_encode64("#{@story.id}-#{@story.title}"), format: :pdf),
+                      target: :_blank,
+                      class: 'add-link'
+
           - unless story.ended?
             - if story.enabled?
               = button_to "Mettre en pause l'aventure",
@@ -141,7 +139,15 @@
                       story_path(story),
                       method: :delete,
                       class: 'destroy-button',
-                      data: { turbo_confirm: "Voulez-vous supprimer de cette aventure ? Cette action est irréversible et entraînera également une suppression sur Nostr" }
+                      data: { turbo_confirm: "Voulez-vous supprimer cette aventure ? Cette action est irréversible et entraînera également une suppression sur Nostr" }
+
+        .text-center
+          p.text-xs.italic
+            | Créé le
+            =< l(story.created_at)
+          p.text-xs.italic
+            | Mis à jour le
+            =< l(story.updated_at)
 
     = render 'turbo_confirm'
 

--- a/app/views/stories/_form.html.slim
+++ b/app/views/stories/_form.html.slim
@@ -104,7 +104,9 @@ details.panel-info.mb-5
             = ff.input :minimum_poll_sats, wrapper_html: { class: 'w-full hidden' }
             = ff.input :maximum_poll_sats, wrapper_html: { class: 'w-full hidden' }
 
-          = ff.input :publish_previous
+          .flex.flex-col.lg:flex-row.items-center.justify-between.gap-3.mb-3
+            = ff.input :publish_previous
+            = ff.input :read_as_pdf
 
         section.mb-5
           p.text-xl.font-semibold.mb-3.border-b.dark:border-gray-600.dark:text-gray-600 Média

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,7 +18,9 @@ Rails.application.configure do
   config.server_timing = true
 
   port = ENV.fetch('PORT', 3000)
-  host = ENV.fetch('HOST', 'http://localhost')
+  host = ENV.fetch('BASE_URL', 'localhost')
+
+  routes.default_url_options = { host: host, port: port }
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,12 @@
+WickedPdf.config = {
+  encoding: 'utf8',
+  page_size: 'A4',
+  orientation: 'Portrait',
+  layout: 'application',
+  margin: {
+    top: 10,
+    bottom: 10,
+    left: 10,
+    right: 10
+  }
+}

--- a/config/locales/action_policy.fr.yml
+++ b/config/locales/action_policy.fr.yml
@@ -1,3 +1,6 @@
 fr:
   action_policy:
     default: Vous n'avez pas l'autorisation d'effectuer cette action.
+
+    public/story_policy:
+      show?: L'histoire n'est pas configurée pour être lue en PDF ou n'est pas encore achevée

--- a/config/locales/chapters.en.yml
+++ b/config/locales/chapters.en.yml
@@ -7,6 +7,13 @@ en:
         - follow this account on Nostr so you don't miss any new adventures
         - check out flownaely.cafe ☕
 
+      content_with_pdf_url: |-
+        If you enjoyed this story, please:
+
+        - download this story as PDF at %{public_pdf_url}
+        - follow this account on Nostr so you don't miss any new adventures
+        - check out flownaely.cafe ☕
+
     text_note:
       next_adventure_questions:
         - How will the adventure continue?

--- a/config/locales/chapters.fr.yml
+++ b/config/locales/chapters.fr.yml
@@ -7,6 +7,13 @@ fr:
         - suivre ce compte sur Nostr pour ne rater aucune nouvelle aventure
         - aller faire un tour sur flownaely.cafe ☕
 
+      content_with_pdf_url: |-
+        Si cette histoire vous a plu, n'hésitez pas à:
+
+        - télécharger l'histoire en PDF sur %{public_pdf_url}
+        - suivre ce compte sur Nostr pour ne rater aucune nouvelle aventure
+        - aller faire un tour sur flownaely.cafe ☕
+
     text_note:
       next_adventure_questions:
         - Comment l'aventure va-t-elle continuer ?

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -8,9 +8,11 @@ option_labels: &option_labels
   minimum_poll_sats: Nombre minimum de sats pour voter
   maximum_poll_sats: Nombre maximum de sats pour voter
   publish_previous: Publier le chapitre précédent ?
+  read_as_pdf: Lire en PDF ?
 
 option_hints: &option_hints
   publish_previous: Si coché, le chapitre précédent le chapitre courant sera publié s'il ne l'a pas encore été
+  read_as_pdf: Si coché, l'aventure sera lisible en format PDF une fois publiée intégralement sur Nostr
 
 fr:
   simple_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
   resource :sessions, only: %i[new create destroy]
   resources :password_resets, only: %i[new create edit update]
 
+  # Public resources
+  scope :p do
+    get 's/:id', controller: 'public/stories', action: 'show', as: :public_story
+  end
+
   resources :stories, only: %i[new create show update destroy] do
     scope module: :stories do
       resource :covers, only: %i[update]

--- a/spec/factories/chapters.rb
+++ b/spec/factories/chapters.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
     trait :published do
       published_at { 1.day.ago }
+      nostr_identifier { SecureRandom.hex }
     end
   end
 end

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :story do
+    title { FFaker::Lorem.sentence }
     summary { FFaker::Lorem.sentence }
 
     thematic

--- a/spec/requests/public/stories_controller_spec.rb
+++ b/spec/requests/public/stories_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Public::StoriesController do
+  describe 'GET /p/s/:id.pdf' do
+    subject(:action) { get "/p/s/#{id}.pdf" }
+
+    let(:id) { Base64.strict_encode64("#{story.id}-#{story.title}") }
+
+    context 'when story is viewable as PDF' do
+      let(:story) { create :story, :ended }
+
+      before do
+        create :chapter, :published, story: story
+        action
+      end
+
+      it { expect(response).to have_http_status :ok }
+    end
+
+    context 'when story is not viewable as PDF' do
+      let(:story) { create :story }
+
+      before { action }
+
+      it { expect(response).to have_http_status :found }
+      it { expect(response).to redirect_to new_sessions_path }
+      it { expect(flash[:alert]).to eq I18n.t('action_policy.public/story_policy.show?') }
+    end
+  end
+end


### PR DESCRIPTION
Resolves #94

Add a new way to read stories with PDF format.
Each stories is now configurable to allow a public PDF endpoint that generate the full complete story.

Link will be displayed on the back cover note if option is enabled while created.

Details:
- Add `wicked_pdf` and `wkhtmltopdf-binary` gems
- Add a new endpoint to render a story as PDF
- Add layout and template for PDF story rendering