### PR TITLE
Use `uuid` as primary key type instead of `bigint`

### DIFF
--- a/app/controllers/public/stories_controller.rb
+++ b/app/controllers/public/stories_controller.rb
@@ -16,12 +16,7 @@ module Public
     private
 
     def set_story
-      @story = Story.find(id)
-    end
-
-    # TODO: Use `uuid` as primary key for stories
-    def id
-      Base64.strict_decode64(params[:id])
+      @story = Story.find(params[:id])
     end
 
     def unauthorized_access(e)

--- a/app/models/atmosphere_prompt.rb
+++ b/app/models/atmosphere_prompt.rb
@@ -6,7 +6,7 @@ end
 #
 # Table name: prompts
 #
-#  id            :bigint(8)        not null, primary key
+#  id            :uuid             not null, primary key
 #  type          :string
 #  title         :string
 #  body          :text

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -116,7 +116,7 @@ end
 #
 # Table name: chapters
 #
-#  id                          :bigint(8)        not null, primary key
+#  id                          :uuid             not null, primary key
 #  title                       :string
 #  content                     :text
 #  summary                     :string
@@ -124,7 +124,7 @@ end
 #  nostr_identifier            :string
 #  replicate_identifier        :string
 #  replicate_raw_response_body :json             not null
-#  story_id                    :bigint(8)        not null
+#  story_id                    :uuid             not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  prompt                      :text

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -33,7 +33,7 @@ end
 #
 # Table name: characters
 #
-#  id         :bigint(8)        not null, primary key
+#  id         :uuid             not null, primary key
 #  first_name :string
 #  last_name  :string
 #  biography  :text

--- a/app/models/characters_story.rb
+++ b/app/models/characters_story.rb
@@ -7,8 +7,8 @@ end
 #
 # Table name: characters_stories
 #
-#  character_id :bigint(8)        not null
-#  story_id     :bigint(8)        not null
+#  character_id :uuid             not null
+#  story_id     :uuid             not null
 #
 # Indexes
 #

--- a/app/models/media_prompt.rb
+++ b/app/models/media_prompt.rb
@@ -8,7 +8,7 @@ end
 #
 # Table name: prompts
 #
-#  id            :bigint(8)        not null, primary key
+#  id            :uuid             not null, primary key
 #  type          :string
 #  title         :string
 #  body          :text

--- a/app/models/narrator_prompt.rb
+++ b/app/models/narrator_prompt.rb
@@ -6,7 +6,7 @@ end
 #
 # Table name: prompts
 #
-#  id            :bigint(8)        not null, primary key
+#  id            :uuid             not null, primary key
 #  type          :string
 #  title         :string
 #  body          :text

--- a/app/models/nostr_user.rb
+++ b/app/models/nostr_user.rb
@@ -92,7 +92,7 @@ end
 #
 # Table name: nostr_users
 #
-#  id                :bigint(8)        not null, primary key
+#  id                :uuid             not null, primary key
 #  private_key       :string
 #  language          :string(2)        default("EN"), not null
 #  created_at        :datetime         not null

--- a/app/models/nostr_users_relay.rb
+++ b/app/models/nostr_users_relay.rb
@@ -7,8 +7,8 @@ end
 #
 # Table name: nostr_users_relays
 #
-#  nostr_user_id :bigint(8)        not null
-#  relay_id      :bigint(8)        not null
+#  nostr_user_id :uuid             not null
+#  relay_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -23,7 +23,7 @@ end
 #
 # Table name: places
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :uuid             not null, primary key
 #  name        :string
 #  description :text
 #  enabled     :boolean          default(TRUE), not null

--- a/app/models/places_story.rb
+++ b/app/models/places_story.rb
@@ -7,8 +7,8 @@ end
 #
 # Table name: places_stories
 #
-#  place_id :bigint(8)        not null
-#  story_id :bigint(8)        not null
+#  place_id :uuid             not null
+#  story_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -14,7 +14,7 @@ end
 #
 # Table name: prompts
 #
-#  id            :bigint(8)        not null, primary key
+#  id            :uuid             not null, primary key
 #  type          :string
 #  title         :string
 #  body          :text

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -70,7 +70,7 @@ end
 #
 # Table name: relays
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :uuid             not null, primary key
 #  url         :string
 #  description :text
 #  enabled     :boolean          default(TRUE), not null

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -219,7 +219,7 @@ end
 #
 # Table name: stories
 #
-#  id                          :bigint(8)        not null, primary key
+#  id                          :uuid             not null, primary key
 #  title                       :string
 #  chapters_count              :integer          default(0), not null
 #  adventure_ended_at          :datetime
@@ -230,18 +230,18 @@ end
 #  replicate_identifier        :string
 #  replicate_raw_request_body  :json             not null
 #  replicate_raw_response_body :json             not null
-#  thematic_id                 :bigint(8)
+#  thematic_id                 :uuid
 #  enabled                     :boolean          default(TRUE), not null
 #  nostr_identifier            :string
-#  nostr_user_id               :bigint(8)
+#  nostr_user_id               :uuid
 #  summary                     :string
 #  back_cover_nostr_identifier :string
 #  publication_rule            :integer          default("do_not_publish"), not null
 #  status                      :integer          default("draft"), not null
 #  options                     :jsonb            not null
-#  media_prompt_id             :bigint(8)
-#  narrator_prompt_id          :bigint(8)
-#  atmosphere_prompt_id        :bigint(8)
+#  media_prompt_id             :uuid
+#  narrator_prompt_id          :uuid
+#  atmosphere_prompt_id        :uuid
 #
 # Indexes
 #

--- a/app/models/thematic.rb
+++ b/app/models/thematic.rb
@@ -24,7 +24,7 @@ end
 #
 # Table name: thematics
 #
-#  id             :bigint(8)        not null, primary key
+#  id             :uuid             not null, primary key
 #  identifier     :string
 #  name_fr        :string
 #  name_en        :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ end
 #
 # Table name: users
 #
-#  id                                  :bigint(8)        not null, primary key
+#  id                                  :uuid             not null, primary key
 #  email                               :string           not null
 #  crypted_password                    :string
 #  salt                                :string

--- a/app/services/nostr_publisher/back_cover.rb
+++ b/app/services/nostr_publisher/back_cover.rb
@@ -21,10 +21,7 @@ module NostrPublisher
     def body
       return main_body unless options.read_as_pdf?
 
-      pdf_url = public_story_url(
-        Base64.strict_encode64("#{story.id}-#{story.title}"),
-        format: :pdf
-      )
+      pdf_url = public_story_url(story, format: :pdf)
 
       main_body_with_pdf_url(pdf_url)
     end

--- a/app/views/stories/_details.html.slim
+++ b/app/views/stories/_details.html.slim
@@ -116,7 +116,7 @@
         .flex.items-center.gap-3
           - if allowed_to?(:show?, @story, namespace: Public)
             = link_to 'Lire en PDF',
-                      public_story_path(Base64.strict_encode64("#{@story.id}-#{@story.title}"), format: :pdf),
+                      public_story_path(story, format: :pdf),
                       target: :_blank,
                       class: 'add-link'
 

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,5 +1,5 @@
 Rails.application.config.generators do |g|
-  g.orm :active_record
+  g.orm :active_record, primary_key_type: :uuid
   g.assets false
   g.helper false
   g.jbuilder false

--- a/db/migrate/20230715083655_sorcery_core.rb
+++ b/db/migrate/20230715083655_sorcery_core.rb
@@ -1,6 +1,6 @@
 class SorceryCore < ActiveRecord::Migration[7.0]
   def change
-    create_table :users do |t|
+    create_table :users, id: :uuid do |t|
       t.string :email, null: false, index: { unique: true }
       t.string :crypted_password
       t.string :salt

--- a/db/migrate/20230715093246_create_stories.rb
+++ b/db/migrate/20230715093246_create_stories.rb
@@ -1,6 +1,6 @@
 class CreateStories < ActiveRecord::Migration[7.0]
   def change
-    create_table :stories do |t|
+    create_table :stories, id: :uuid do |t|
       t.string :title
       t.integer :chapters_count, null: false, default: 0
       t.datetime :adventure_ended_at

--- a/db/migrate/20230715093412_create_chapters.rb
+++ b/db/migrate/20230715093412_create_chapters.rb
@@ -1,6 +1,6 @@
 class CreateChapters < ActiveRecord::Migration[7.0]
   def change
-    create_table :chapters do |t|
+    create_table :chapters, id: :uuid do |t|
       t.string :title
       t.text :content
       t.string :summary
@@ -8,7 +8,7 @@ class CreateChapters < ActiveRecord::Migration[7.0]
       t.string :nostr_identifier, index: { unique: true }
       t.string :replicate_identifier, index: { unique: true }
       t.json :raw_response_body, null: false, default: {}
-      t.references :story, null: false, foreign_key: true
+      t.references :story, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20230722204304_create_nostr_users.rb
+++ b/db/migrate/20230722204304_create_nostr_users.rb
@@ -1,6 +1,6 @@
 class CreateNostrUsers < ActiveRecord::Migration[7.0]
   def change
-    create_table :nostr_users do |t|
+    create_table :nostr_users, id: :uuid do |t|
       t.string :name
       t.string :public_key
       t.string :private_key

--- a/db/migrate/20230726151034_create_thematics.rb
+++ b/db/migrate/20230726151034_create_thematics.rb
@@ -1,6 +1,6 @@
 class CreateThematics < ActiveRecord::Migration[7.0]
   def change
-    create_table :thematics do |t|
+    create_table :thematics, id: :uuid do |t|
       t.string :identifier, index: { unique: true }
       t.string :name_fr
       t.string :name_en

--- a/db/migrate/20230726153833_add_thematic_id_to_story.rb
+++ b/db/migrate/20230726153833_add_thematic_id_to_story.rb
@@ -1,5 +1,5 @@
 class AddThematicIdToStory < ActiveRecord::Migration[7.0]
   def change
-    add_reference :stories, :thematic, foreign_key: true
+    add_reference :stories, :thematic, foreign_key: true, type: :uuid
   end
 end

--- a/db/migrate/20230728121239_add_nostr_user_id_to_story.rb
+++ b/db/migrate/20230728121239_add_nostr_user_id_to_story.rb
@@ -1,5 +1,5 @@
 class AddNostrUserIdToStory < ActiveRecord::Migration[7.0]
   def change
-    add_reference :stories, :nostr_user, foreign_key: true
+    add_reference :stories, :nostr_user, foreign_key: true, type: :uuid
   end
 end

--- a/db/migrate/20230809112056_create_relays.rb
+++ b/db/migrate/20230809112056_create_relays.rb
@@ -1,6 +1,6 @@
 class CreateRelays < ActiveRecord::Migration[7.0]
   def change
-    create_table :relays do |t|
+    create_table :relays, id: :uuid do |t|
       t.string :url, index: { unique: true }
       t.text :description
       t.boolean :enabled, null: false, default: true

--- a/db/migrate/20230809112859_create_nostr_users_relays.rb
+++ b/db/migrate/20230809112859_create_nostr_users_relays.rb
@@ -1,6 +1,6 @@
 class CreateNostrUsersRelays < ActiveRecord::Migration[7.0]
   def change
-    create_join_table :nostr_users, :relays do |t|
+    create_join_table :nostr_users, :relays, column_options: { type: :uuid } do |t|
       t.index %i[nostr_user_id relay_id], unique: true
     end
   end

--- a/db/migrate/20230913085828_create_characters.rb
+++ b/db/migrate/20230913085828_create_characters.rb
@@ -1,6 +1,6 @@
 class CreateCharacters < ActiveRecord::Migration[7.0]
   def change
-    create_table :characters do |t|
+    create_table :characters, id: :uuid do |t|
       t.string :first_name
       t.string :last_name
       t.text :biography

--- a/db/migrate/20230913090502_create_join_table_characters_stories.rb
+++ b/db/migrate/20230913090502_create_join_table_characters_stories.rb
@@ -1,6 +1,6 @@
 class CreateJoinTableCharactersStories < ActiveRecord::Migration[7.0]
   def change
-    create_join_table :characters, :stories do |t|
+    create_join_table :characters, :stories, column_options: { type: :uuid } do |t|
       t.index :character_id
       t.index :story_id
       t.index %i[character_id story_id], unique: true

--- a/db/migrate/20230913153558_create_places.rb
+++ b/db/migrate/20230913153558_create_places.rb
@@ -1,6 +1,6 @@
 class CreatePlaces < ActiveRecord::Migration[7.0]
   def change
-    create_table :places do |t|
+    create_table :places, id: :uuid do |t|
       t.string :name
       t.text :description
       t.boolean :enabled, null: false, default: true

--- a/db/migrate/20230913153935_create_join_table_places_stories.rb
+++ b/db/migrate/20230913153935_create_join_table_places_stories.rb
@@ -1,6 +1,6 @@
 class CreateJoinTablePlacesStories < ActiveRecord::Migration[7.0]
   def change
-    create_join_table :places, :stories do |t|
+    create_join_table :places, :stories, column_options: { type: :uuid } do |t|
       t.index :place_id
       t.index :story_id
     end

--- a/db/migrate/20230914082159_create_prompts.rb
+++ b/db/migrate/20230914082159_create_prompts.rb
@@ -1,6 +1,6 @@
 class CreatePrompts < ActiveRecord::Migration[7.0]
   def change
-    create_table :prompts do |t|
+    create_table :prompts, id: :uuid do |t|
       t.string :type
       t.string :title
       t.text :body

--- a/db/migrate/20230914084838_add_prompt_ids_to_story.rb
+++ b/db/migrate/20230914084838_add_prompt_ids_to_story.rb
@@ -1,7 +1,7 @@
 class AddPromptIdsToStory < ActiveRecord::Migration[7.0]
   def change
-    add_reference :stories, :media_prompt, foreign_key: { to_table: :prompts }
-    add_reference :stories, :narrator_prompt, foreign_key: { to_table: :prompts }
-    add_reference :stories, :atmosphere_prompt, foreign_key: { to_table: :prompts }
+    add_reference :stories, :media_prompt, foreign_key: { to_table: :prompts }, type: :uuid
+    add_reference :stories, :narrator_prompt, foreign_key: { to_table: :prompts }, type: :uuid
+    add_reference :stories, :atmosphere_prompt, foreign_key: { to_table: :prompts }, type: :uuid
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,17 +14,17 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.uuid "record_id", null: false
+    t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -36,13 +36,13 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "chapters", force: :cascade do |t|
+  create_table "chapters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title"
     t.text "content"
     t.string "summary"
@@ -50,7 +50,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.string "nostr_identifier"
     t.string "replicate_identifier"
     t.json "replicate_raw_response_body", default: {}, null: false
-    t.bigint "story_id", null: false
+    t.uuid "story_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "prompt"
@@ -65,7 +65,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.index ["story_id"], name: "index_chapters_on_story_id"
   end
 
-  create_table "characters", force: :cascade do |t|
+  create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.text "biography"
@@ -76,14 +76,14 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
   end
 
   create_table "characters_stories", id: false, force: :cascade do |t|
-    t.bigint "character_id", null: false
-    t.bigint "story_id", null: false
+    t.uuid "character_id", null: false
+    t.uuid "story_id", null: false
     t.index ["character_id", "story_id"], name: "index_characters_stories_on_character_id_and_story_id", unique: true
     t.index ["character_id"], name: "index_characters_stories_on_character_id"
     t.index ["story_id"], name: "index_characters_stories_on_story_id"
   end
 
-  create_table "nostr_users", force: :cascade do |t|
+  create_table "nostr_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "private_key"
     t.string "language", limit: 2, default: "EN", null: false
     t.datetime "created_at", null: false
@@ -102,12 +102,12 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
   end
 
   create_table "nostr_users_relays", id: false, force: :cascade do |t|
-    t.bigint "nostr_user_id", null: false
-    t.bigint "relay_id", null: false
+    t.uuid "nostr_user_id", null: false
+    t.uuid "relay_id", null: false
     t.index ["nostr_user_id", "relay_id"], name: "index_nostr_users_relays_on_nostr_user_id_and_relay_id", unique: true
   end
 
-  create_table "places", force: :cascade do |t|
+  create_table "places", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.boolean "enabled", default: true, null: false
@@ -116,13 +116,13 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
   end
 
   create_table "places_stories", id: false, force: :cascade do |t|
-    t.bigint "place_id", null: false
-    t.bigint "story_id", null: false
+    t.uuid "place_id", null: false
+    t.uuid "story_id", null: false
     t.index ["place_id"], name: "index_places_stories_on_place_id"
     t.index ["story_id"], name: "index_places_stories_on_story_id"
   end
 
-  create_table "prompts", force: :cascade do |t|
+  create_table "prompts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type"
     t.string "title"
     t.text "body"
@@ -136,7 +136,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "relays", force: :cascade do |t|
+  create_table "relays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "url"
     t.text "description"
     t.boolean "enabled", default: true, null: false
@@ -245,7 +245,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
-  create_table "stories", force: :cascade do |t|
+  create_table "stories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title"
     t.integer "chapters_count", default: 0, null: false
     t.datetime "adventure_ended_at"
@@ -256,18 +256,18 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.string "replicate_identifier"
     t.json "replicate_raw_request_body", default: {}, null: false
     t.json "replicate_raw_response_body", default: {}, null: false
-    t.bigint "thematic_id"
+    t.uuid "thematic_id"
     t.boolean "enabled", default: true, null: false
     t.string "nostr_identifier"
-    t.bigint "nostr_user_id"
+    t.uuid "nostr_user_id"
     t.string "summary"
     t.string "back_cover_nostr_identifier"
     t.integer "publication_rule", default: 0, null: false
     t.integer "status", default: 0, null: false
     t.jsonb "options", default: {}, null: false
-    t.bigint "media_prompt_id"
-    t.bigint "narrator_prompt_id"
-    t.bigint "atmosphere_prompt_id"
+    t.uuid "media_prompt_id"
+    t.uuid "narrator_prompt_id"
+    t.uuid "atmosphere_prompt_id"
     t.index ["atmosphere_prompt_id"], name: "index_stories_on_atmosphere_prompt_id"
     t.index ["back_cover_nostr_identifier"], name: "index_stories_on_back_cover_nostr_identifier", unique: true
     t.index ["media_prompt_id"], name: "index_stories_on_media_prompt_id"
@@ -278,7 +278,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.index ["thematic_id"], name: "index_stories_on_thematic_id"
   end
 
-  create_table "thematics", force: :cascade do |t|
+  create_table "thematics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "identifier"
     t.string "name_fr"
     t.string "name_en"
@@ -291,7 +291,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.index ["identifier"], name: "index_thematics_on_identifier", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"

--- a/spec/requests/public/stories_controller_spec.rb
+++ b/spec/requests/public/stories_controller_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Public::StoriesController do
   describe 'GET /p/s/:id.pdf' do
-    subject(:action) { get "/p/s/#{id}.pdf" }
-
-    let(:id) { Base64.strict_encode64("#{story.id}-#{story.title}") }
+    subject(:action) { get "/p/s/#{story.id}.pdf" }
 
     context 'when story is viewable as PDF' do
       let(:story) { create :story, :ended }


### PR DESCRIPTION
Resolves #98

Using `uuid` instead of `bigint` avoid users to know incremental id to test in URL.