### PR TITLE
Add `ruby-lsp-rails` gem to improve rich features in editors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development do
   gem 'bullet'
   gem 'chusaku', require: false
   gem 'letter_opener'
+  gem 'ruby-lsp-rails'
   gem 'shog'
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    prism (0.19.0)
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
@@ -347,6 +348,16 @@ GEM
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
+    ruby-lsp (0.13.2)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 0.19.0, < 0.20)
+      sorbet-runtime (>= 0.5.5685)
+    ruby-lsp-rails (0.2.8)
+      actionpack (>= 6.0)
+      activerecord (>= 6.0)
+      railties (>= 6.0)
+      ruby-lsp (>= 0.13.0, < 0.14.0)
+      sorbet-runtime (>= 0.5.9897)
     ruby-next-core (1.0.0)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.0)
@@ -379,6 +390,7 @@ GEM
       version_gem (~> 1.1, >= 1.1.1)
     solid_queue (0.1.2)
       rails (>= 7.0.3.1)
+    sorbet-runtime (0.5.11178)
     sorcery (0.16.5)
       bcrypt (~> 3.1)
       oauth (>= 0.6)
@@ -476,6 +488,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby-lsp-rails
   shog
   shoulda-matchers
   simple_form


### PR DESCRIPTION
Adding the [ruby-lsp-rails](https://github.com/Shopify/ruby-lsp-rails) gem to the project allows to get a better understanding of methods and Rails code inside the editor showing as a hover popup (for example visualize a model attributes with type).

Rails 8 planned to make it integrated into the next major version so let's experiment it until it reach the big release.