### PR TITLE
Update enum syntax

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -2,7 +2,7 @@ class Chapter < ApplicationRecord
   include Coverable
   include NSFWCoverable
 
-  enum status: { draft: 0, completed: 1 }
+  enum :status, { draft: 0, completed: 1 }, validate: true
 
   belongs_to :story, counter_cache: true, touch: true
 

--- a/app/models/nostr_user.rb
+++ b/app/models/nostr_user.rb
@@ -2,7 +2,7 @@ class NostrUser < ApplicationRecord
   # include ActionView::Helpers::AssetTagHelper
   include Rails.application.routes.url_helpers
 
-  enum mode: { generated: 0, imported: 1 }, _default: :generated
+  enum :mode, { generated: 0, imported: 1 }, default: :generated, validate: true
 
   has_many :nostr_users_relays, dependent: :delete_all
   has_many :relays, -> { by_position }, through: :nostr_users_relays

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -2,13 +2,13 @@ class Story < ApplicationRecord
   include Coverable
   include NSFWCoverable
 
-  enum mode: { complete: 0, dropper: 1 }, _default: :complete
-  enum status: { draft: 0, completed: 1 }, _default: :draft
-  enum publication_rule: {
+  enum :mode, { complete: 0, dropper: 1 }, default: :complete, validate: true
+  enum :status, { draft: 0, completed: 1 }, default: :draft, validate: true
+  enum :publication_rule, {
     do_not_publish: 0,
     publish_first_chapter: 1,
     publish_all_chapters: 2
-  }, _default: :do_not_publish
+  }, default: :do_not_publish, validate: true
 
   attribute :options, StoryOption.to_type
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   EMAIL_REGEX = /\A[^@\s]+@([^@.\s]+\.)+[^@.\s]+\z/
 
-  enum role: { standard: 0, admin: 1, super_admin: 2 }
+  enum :role, { standard: 0, admin: 1, super_admin: 2 }, validate: true
 
   has_one_attached :avatar
 

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Chapter do
+  describe '[validations rules]' do
+    subject { build_stubbed :chapter }
+
+    it { is_expected.to define_enum_for(:status).with_values(described_class.statuses.keys) }
+  end
+end

--- a/spec/models/nostr_user_spec.rb
+++ b/spec/models/nostr_user_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe NostrUser do
+  describe '[validations rules]' do
+    subject { build_stubbed :nostr_user }
+
+    it { is_expected.to define_enum_for(:mode).with_values(described_class.modes.keys) }
+  end
+
   describe '#mode' do
     subject(:nostr_user) do
       described_class.new(mode: mode, display_name: 'John Doe')

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Story do
     it { is_expected.to belong_to(:thematic) }
     it { is_expected.to validate_presence_of(:mode) }
     it { is_expected.to define_enum_for(:mode).with_values(described_class.modes.keys) }
+    it { is_expected.to define_enum_for(:status).with_values(described_class.statuses.keys) }
     it { is_expected.to define_enum_for(:publication_rule).with_values(described_class.publication_rules.keys) }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  it { is_expected.to define_enum_for(:role).with_values(described_class.roles.keys) }
+end


### PR DESCRIPTION
Rails updated the way enums are defined to avoid a leading `_` to reserved options such as `_default`, `_prefix`, `_suffix` and `_scopes`.

Also add a `validate: true` option to each enum to return false when saving if value is not defined in the enum instead of raising an exception.