### PR TITLE
Add company resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,9 @@ RSpec/MultipleMemoizedHelpers:
   Exclude:
     - spec/models/option_spec.rb
     - spec/requests/stories_controller_spec.rb
+    - spec/policies/prompt_policy_spec.rb
+    - spec/policies/stories/chapter_policy_spec.rb
+    - spec/policies/stories/cover_policy_spec.rb
 
 Performance/CollectionLiteralInLoop:
   Exclude:

--- a/app/assets/stylesheets/components/form.css
+++ b/app/assets/stylesheets/components/form.css
@@ -29,7 +29,7 @@ textarea.text, input.file {
 }
 
 .hint {
-  @apply inline-block mt-2 text-blue-500 dark:text-blue-400 text-sm;
+  @apply block mt-2 text-blue-500 dark:text-blue-400 text-sm;
 }
 
 .hint:before {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,9 +8,13 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :warning, :info
 
-  helper_method :options
+  helper_method :company, :options
 
   private
+
+  def company
+    Current.company ||= current_user.company
+  end
 
   def not_authenticated
     redirect_to new_sessions_path,
@@ -29,6 +33,6 @@ class ApplicationController < ActionController::Base
   end
 
   def options
-    @options ||= Setting.first.chapter_options
+    @options ||= company.setting.chapter_options
   end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -5,21 +5,21 @@ class CharactersController < ApplicationController
   def index
     authorize! Character
 
-    @characters = Character.order(id: :desc)
+    @characters = company.characters.order(id: :desc)
   end
 
   # @route GET /characters/new (new_character)
   def new
     authorize! Character
 
-    @character = Character.new
+    @character = company.characters.new
   end
 
   # @route POST /characters (characters)
   def create
     authorize! Character
 
-    @character = Character.new(character_params)
+    @character = company.characters.new(character_params)
 
     respond_to do |format|
       if @character.save
@@ -63,7 +63,7 @@ class CharactersController < ApplicationController
   private
 
   def set_character
-    @character = Character.find(params[:id])
+    @character = company.characters.find(params[:id])
   end
 
   def character_params

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -4,23 +4,23 @@ class HomesController < ApplicationController
   # @route GET / (root)
   def show
     if display_ended?
-      @stories = Story.ended
+      @stories = company.stories.ended
     else
-      @stories = Story.currents
+      @stories = company.stories.currents
 
-      @publishable_stories = Story.publishable
+      @publishable_stories = company.stories.publishable
 
       @active_stories = {}
-      NostrUser.pluck(:language).each do |language|
-        @active_stories[language] = Story.publishable(language: language).first
+      company.nostr_users.pluck(:language).each do |language|
+        @active_stories[language] = company.stories.publishable(language: language).first
       end
     end
 
     begin
       if modal_chapter?
-        @chapter_popup = Chapter.find_by(id: chapter_id, story_id: story_id)
+        @chapter_popup = company.chapters.find_by(id: chapter_id, story_id: story_id)
       elsif modal_story?
-        @story_popup = Story.find_by(id: story_id)
+        @story_popup = company.stories.find_by(id: story_id)
       end
     rescue URI::InvalidURIError
       @chapter_popup = nil

--- a/app/controllers/nostr_users/import_profiles_controller.rb
+++ b/app/controllers/nostr_users/import_profiles_controller.rb
@@ -4,14 +4,14 @@ module NostrUsers
     def new
       authorize! NostrUser
 
-      @nostr_user = NostrUser.new
+      @nostr_user = company.nostr_users.new
     end
 
     # @route POST /nostr_users/import_profiles (import_profiles)
     def create
       authorize! NostrUser
 
-      @nostr_user = NostrUser.new(nostr_user_params) do |nostr_user|
+      @nostr_user = company.nostr_users.new(nostr_user_params) do |nostr_user|
         nostr_user.mode = :imported
       end
 

--- a/app/controllers/nostr_users/private_keys_controller.rb
+++ b/app/controllers/nostr_users/private_keys_controller.rb
@@ -32,7 +32,7 @@ module NostrUsers
     end
 
     def set_nostr_user
-      @nostr_user = NostrUser.find(params[:id])
+      @nostr_user = company.nostr_users.find(params[:id])
     end
   end
 end

--- a/app/controllers/nostr_users/refresh_profiles_controller.rb
+++ b/app/controllers/nostr_users/refresh_profiles_controller.rb
@@ -19,7 +19,7 @@ module NostrUsers
     private
 
     def set_nostr_user
-      @nostr_user = NostrUser.find(params[:id])
+      @nostr_user = company.nostr_users.find(params[:id])
     end
   end
 end

--- a/app/controllers/nostr_users_controller.rb
+++ b/app/controllers/nostr_users_controller.rb
@@ -5,21 +5,21 @@ class NostrUsersController < ApplicationController
   def index
     authorize! NostrUser
 
-    @nostr_users = NostrUser.order(id: :asc)
+    @nostr_users = company.nostr_users.order(id: :asc)
   end
 
   # @route GET /nostr_users/new (new_nostr_user)
   def new
     authorize! NostrUser
 
-    @nostr_user = NostrUser.new(mode: :generated)
+    @nostr_user = company.nostr_users.new(mode: :generated)
   end
 
   # @route POST /nostr_users (nostr_users)
   def create
     authorize! NostrUser
 
-    @nostr_user = NostrUser.new(nostr_user_create_params) do |nostr_user|
+    @nostr_user = company.nostr_users.new(nostr_user_create_params) do |nostr_user|
       nostr_user.mode = :generated
       nostr_user.relays = [Relay.main]
     end
@@ -69,7 +69,7 @@ class NostrUsersController < ApplicationController
   private
 
   def set_nostr_user
-    @nostr_user = NostrUser.find(params[:id])
+    @nostr_user = company.nostr_users.find(params[:id])
   end
 
   def nostr_user_create_params

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -5,21 +5,21 @@ class PlacesController < ApplicationController
   def index
     authorize! Place
 
-    @places = Place.order(id: :desc)
+    @places = company.places.order(id: :desc)
   end
 
   # @route GET /places/new (new_place)
   def new
     authorize! Place
 
-    @place = Place.new
+    @place = company.places.new
   end
 
   # @route POST /places (places)
   def create
     authorize! Place
 
-    @place = Place.new(place_params)
+    @place = company.places.new(place_params)
 
     respond_to do |format|
       if @place.save
@@ -63,7 +63,7 @@ class PlacesController < ApplicationController
   private
 
   def set_place
-    @place = Place.find(params[:id])
+    @place = company.places.find(params[:id])
   end
 
   def place_params

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -6,9 +6,9 @@ class PromptsController < ApplicationController
     authorize! Prompt
 
     @prompts = if params[:archived].to_bool
-      Prompt.archived
+      company.prompts.archived
     else
-      Prompt.available
+      company.prompts.available
     end
   end
 
@@ -47,7 +47,9 @@ class PromptsController < ApplicationController
                       return
     end
 
-    @prompt = type.constantize.new(prompt_params)
+    @prompt = type.constantize.new(prompt_params) do |prompt|
+      prompt.company = company
+    end
 
     respond_to do |format|
       if @prompt.save
@@ -115,7 +117,7 @@ class PromptsController < ApplicationController
   private
 
   def set_prompt
-    @prompt = Prompt.find(params[:id])
+    @prompt = company.prompts.find(params[:id])
   end
 
   def media_prompt_params

--- a/app/controllers/relays/resets_controller.rb
+++ b/app/controllers/relays/resets_controller.rb
@@ -4,7 +4,7 @@ module Relays
     def create
       authorize! Relay, with: ResetListPolicy
 
-      Relay.reset!
+      company.relays.reset!
 
       redirect_to relays_path, notice: 'Les relais ont été réinitialisés'
     end

--- a/app/controllers/relays_controller.rb
+++ b/app/controllers/relays_controller.rb
@@ -5,21 +5,21 @@ class RelaysController < ApplicationController
   def index
     authorize! Relay
 
-    @relays = Relay.all.by_position
+    @relays = company.relays.all.by_position
   end
 
   # @route GET /relays/new (new_relay)
   def new
     authorize! Relay
 
-    @relay = Relay.new
+    @relay = company.relays.new
   end
 
   # @route POST /relays (relays)
   def create
     authorize! Relay
 
-    @relay = Relay.new(relay_params)
+    @relay = company.relays.new(relay_params)
 
     respond_to do |format|
       if @relay.save
@@ -67,7 +67,7 @@ class RelaysController < ApplicationController
   private
 
   def set_relay
-    @relay = Relay.find(params[:id])
+    @relay = company.relays.find(params[:id])
   end
 
   def relay_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     if @user
       # authorize! :dashboard, to: :show?
 
-      flash[:notice] = 'Vous êtes connecté'
+      # flash[:notice] = 'Vous êtes connecté'
 
       redirect_to root_path
     else

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -28,7 +28,7 @@ class SettingsController < ApplicationController
   private
 
   def set_setting
-    @setting = Setting.first
+    @setting = company.setting
   end
 
   def setting_params

--- a/app/controllers/stories/chapters/covers_controller.rb
+++ b/app/controllers/stories/chapters/covers_controller.rb
@@ -22,7 +22,7 @@ module Stories
       private
 
       def set_story
-        @story = Story.find(params[:story_id])
+        @story = company.stories.find(params[:story_id])
       end
 
       def set_chapter

--- a/app/controllers/stories/chapters_controller.rb
+++ b/app/controllers/stories/chapters_controller.rb
@@ -84,7 +84,7 @@ module Stories
     private
 
     def set_story
-      @story = Story.find(params[:story_id])
+      @story = company.stories.find(params[:story_id])
     end
 
     def set_chapter

--- a/app/controllers/stories/covers_controller.rb
+++ b/app/controllers/stories/covers_controller.rb
@@ -20,7 +20,7 @@ module Stories
     private
 
     def set_story
-      @story = Story.find(params[:story_id])
+      @story = company.stories.find(params[:story_id])
     end
   end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -5,14 +5,14 @@ class StoriesController < ApplicationController
   def new
     authorize! Story
 
-    @story = Story.new
+    @story = company.stories.new
   end
 
   # @route POST /stories (stories)
   def create
     authorize! Story
 
-    @story = Story.new(story_params)
+    @story = company.stories.new(story_params)
 
     if @story.save
       case mode
@@ -76,7 +76,7 @@ class StoriesController < ApplicationController
   private
 
   def set_story
-    @story = Story.find(params[:id])
+    @story = company.stories.find(params[:id])
   end
 
   def story_params

--- a/app/controllers/thematics_controller.rb
+++ b/app/controllers/thematics_controller.rb
@@ -5,21 +5,21 @@ class ThematicsController < ApplicationController
   def index
     authorize! Thematic
 
-    @thematics = Thematic.all
+    @thematics = company.thematics.all
   end
 
   # @route GET /thematics/new (new_thematic)
   def new
     authorize! Thematic
 
-    @thematic = Thematic.new
+    @thematic = company.thematics.new
   end
 
   # @route POST /thematics (thematics)
   def create
     authorize! Thematic
 
-    @thematic = Thematic.new(thematic_params)
+    @thematic = company.thematics.new(thematic_params)
 
     respond_to do |format|
       if @thematic.save
@@ -67,11 +67,11 @@ class ThematicsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_thematic
-    @thematic = Thematic.find(params[:id])
+    @thematic = company.thematics.find(params[:id])
   end
 
   # Only allow a list of trusted parameters through.
   def thematic_params
-    params.require(:thematic).permit(:identifier, :name_fr, :name_en, :description_fr, :description_en, :enabled)
+    params.require(:thematic).permit(:name_fr, :name_en, :description_fr, :description_en, :enabled)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,10 +18,10 @@ module ApplicationHelper
     enum.keys.map { |k| [klass.human_enum_name(enum_name, k), k] }
   end
 
-  def story_nostr_users_select_options
+  def story_nostr_users_select_options(company)
     all_languages = I18nData.languages(I18n.locale)
 
-    NostrUser.enabled.with_relays.with_attached_picture.map do |nostr_user|
+    company.nostr_users.enabled.with_relays.with_attached_picture.map do |nostr_user|
       language = nostr_user.language.upcase
 
       [
@@ -40,8 +40,8 @@ module ApplicationHelper
     end
   end
 
-  def story_characters_select_options
-    Character.enabled.with_attached_avatar.map do |character|
+  def story_characters_select_options(company)
+    company.characters.enabled.with_attached_avatar.map do |character|
       data_html = nil
 
       if character.avatar.attached?
@@ -60,8 +60,8 @@ module ApplicationHelper
     end
   end
 
-  def story_places_select_options
-    Place.enabled.with_attached_photo.map do |place|
+  def story_places_select_options(company)
+    company.places.enabled.with_attached_photo.map do |place|
       data_html = <<~HTML
         <div class="flex items-center gap-2">
           #{image_tag(place.photo_url, class: 'w-12 h-12 object-cover rounded-full')}

--- a/app/models/atmosphere_prompt.rb
+++ b/app/models/atmosphere_prompt.rb
@@ -16,6 +16,15 @@ end
 #  enabled       :boolean          default(TRUE), not null
 #  position      :integer          default(1), not null
 #  archived_at   :datetime
+#  company_id    :uuid             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_prompts_on_company_id  (company_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -2,6 +2,7 @@ class Character < ApplicationRecord
   include ActionView::Helpers::AssetTagHelper
   include Rails.application.routes.url_helpers
 
+  belongs_to :company
   has_many :characters_stories, dependent: :delete_all
   has_many :stories, through: :characters_stories
 
@@ -38,10 +39,16 @@ end
 #  last_name  :string
 #  biography  :text
 #  enabled    :boolean          default(TRUE), not null
+#  company_id :uuid             not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 # Indexes
 #
+#  index_characters_on_company_id                (company_id)
 #  index_characters_on_first_name_and_last_name  (first_name,last_name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,0 +1,36 @@
+class Company < ApplicationRecord
+  with_options dependent: :destroy do
+    has_one :setting
+    has_many :characters
+    has_many :nostr_users
+    has_many :places
+    has_many :prompts
+    has_many :media_prompts, -> { where(type: 'MediaPrompt') }, inverse_of: :company
+    has_many :narrator_prompts, -> { where(type: 'NarratorPrompt') }, inverse_of: :company
+    has_many :atmosphere_prompts, -> { where(type: 'AtmospherePrompt') }, inverse_of: :company
+    has_many :relays
+    has_many :stories
+    has_many :chapters, through: :stories
+    has_many :thematics
+    has_many :users
+  end
+
+  validates :name, presence: true, uniqueness: true
+
+  has_one_attached :logo
+end
+
+# == Schema Information
+#
+# Table name: companies
+#
+#  id          :uuid             not null, primary key
+#  name        :string
+#  users_count :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_companies_on_name  (name) UNIQUE
+#

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :company
+end

--- a/app/models/media_prompt.rb
+++ b/app/models/media_prompt.rb
@@ -18,6 +18,15 @@ end
 #  enabled       :boolean          default(TRUE), not null
 #  position      :integer          default(1), not null
 #  archived_at   :datetime
+#  company_id    :uuid             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_prompts_on_company_id  (company_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/narrator_prompt.rb
+++ b/app/models/narrator_prompt.rb
@@ -16,6 +16,15 @@ end
 #  enabled       :boolean          default(TRUE), not null
 #  position      :integer          default(1), not null
 #  archived_at   :datetime
+#  company_id    :uuid             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_prompts_on_company_id  (company_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/nostr_user.rb
+++ b/app/models/nostr_user.rb
@@ -1,9 +1,9 @@
 class NostrUser < ApplicationRecord
-  # include ActionView::Helpers::AssetTagHelper
   include Rails.application.routes.url_helpers
 
   enum :mode, { generated: 0, imported: 1 }, default: :generated, validate: true
 
+  belongs_to :company
   has_many :nostr_users_relays, dependent: :delete_all
   has_many :relays, -> { by_position }, through: :nostr_users_relays
   has_many :stories, dependent: :destroy
@@ -95,6 +95,7 @@ end
 #  id                :uuid             not null, primary key
 #  private_key       :string
 #  language          :string(2)        default("EN"), not null
+#  company_id        :uuid             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  stories_count     :integer          default(0), not null
@@ -110,5 +111,10 @@ end
 #
 # Indexes
 #
+#  index_nostr_users_on_company_id   (company_id)
 #  index_nostr_users_on_private_key  (private_key) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -2,6 +2,7 @@ class Place < ApplicationRecord
   include ActionView::Helpers::AssetTagHelper
   include Rails.application.routes.url_helpers
 
+  belongs_to :company
   has_many :places_stories, dependent: :delete_all
   has_many :places, through: :places_stories
 
@@ -27,6 +28,15 @@ end
 #  name        :string
 #  description :text
 #  enabled     :boolean          default(TRUE), not null
+#  company_id  :uuid             not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_places_on_company_id  (company_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -1,13 +1,15 @@
 class Prompt < ApplicationRecord
   include Archivable
 
+  belongs_to :company
+
   validates :title, presence: true
   validates :body, presence: true
 
   scope :enabled, -> { where(enabled: true) }
   scope :by_position, -> { order(:position) }
 
-  acts_as_list scope: [:type]
+  acts_as_list scope: %i[company_id type]
 end
 
 # == Schema Information
@@ -24,6 +26,15 @@ end
 #  enabled       :boolean          default(TRUE), not null
 #  position      :integer          default(1), not null
 #  archived_at   :datetime
+#  company_id    :uuid             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_prompts_on_company_id  (company_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -11,15 +11,16 @@ class Relay < ApplicationRecord
     wss://nos.lol
   ].freeze
 
+  belongs_to :company
   has_many :nostr_users_relays, dependent: :destroy
   has_many :nostr_users, through: :nostr_users_relays
 
-  acts_as_list
+  acts_as_list scope: :company
 
   scope :enabled, -> { where(enabled: true) }
   scope :by_position, -> { order(:position) }
 
-  validates :url, presence: true, uniqueness: { case_sensitive: false }
+  validates :url, presence: true, uniqueness: { case_sensitive: false, scope: :company_id }
 
   after_validation :clean_url
   after_update :delete_nostr_users_association, if: :marked_as_disabled?
@@ -74,11 +75,17 @@ end
 #  url         :string
 #  description :text
 #  enabled     :boolean          default(TRUE), not null
+#  company_id  :uuid             not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  position    :integer          default(1), not null
 #
 # Indexes
 #
-#  index_relays_on_url  (url) UNIQUE
+#  index_relays_on_company_id          (company_id)
+#  index_relays_on_company_id_and_url  (company_id,url) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,8 @@
 class Setting < ApplicationRecord
   attribute :chapter_options, Option.to_type
 
+  belongs_to :company
+
   validates :chapter_options, store_model: { merge_errors: true }
 
   before_create :confirm_singularity
@@ -8,7 +10,7 @@ class Setting < ApplicationRecord
   private
 
   def confirm_singularity
-    raise StandardError.new('There can be only one.') if Setting.exists?
+    raise StandardError.new('There can be only one.') if company.setting&.persisted?
   end
 end
 
@@ -18,6 +20,15 @@ end
 #
 #  id              :bigint(8)        not null, primary key
 #  chapter_options :jsonb            not null
+#  company_id      :uuid             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_settings_on_company_id  (company_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -14,6 +14,7 @@ class Story < ApplicationRecord
 
   attr_accessor :light_form
 
+  belongs_to :company
   belongs_to :thematic, counter_cache: true
   belongs_to :nostr_user, counter_cache: true
 
@@ -224,6 +225,7 @@ end
 #  chapters_count              :integer          default(0), not null
 #  adventure_ended_at          :datetime
 #  raw_response_body           :json             not null
+#  company_id                  :uuid             not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  mode                        :integer          default("complete"), not null
@@ -247,6 +249,7 @@ end
 #
 #  index_stories_on_atmosphere_prompt_id         (atmosphere_prompt_id)
 #  index_stories_on_back_cover_nostr_identifier  (back_cover_nostr_identifier) UNIQUE
+#  index_stories_on_company_id                   (company_id)
 #  index_stories_on_media_prompt_id              (media_prompt_id)
 #  index_stories_on_narrator_prompt_id           (narrator_prompt_id)
 #  index_stories_on_nostr_identifier             (nostr_identifier) UNIQUE
@@ -257,6 +260,7 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (atmosphere_prompt_id => prompts.id)
+#  fk_rails_...  (company_id => companies.id)
 #  fk_rails_...  (media_prompt_id => prompts.id)
 #  fk_rails_...  (narrator_prompt_id => prompts.id)
 #  fk_rails_...  (nostr_user_id => nostr_users.id)

--- a/app/models/thematic.rb
+++ b/app/models/thematic.rb
@@ -1,4 +1,7 @@
 class Thematic < ApplicationRecord
+  belongs_to :company
+  has_many :stories, dependent: :nullify
+
   scope :enabled, -> { where(enabled: true) }
 
   after_destroy_commit do
@@ -9,7 +12,6 @@ class Thematic < ApplicationRecord
   validates :name_en, presence: true
   validates :description_fr, presence: true
   validates :description_en, presence: true
-  validates :identifier, presence: true, uniqueness: { case_sensitive: false }
 
   def name
     name_fr
@@ -25,17 +27,21 @@ end
 # Table name: thematics
 #
 #  id             :uuid             not null, primary key
-#  identifier     :string
 #  name_fr        :string
 #  name_en        :string
 #  description_fr :text
 #  description_en :text
 #  stories_count  :integer          default(0), not null
 #  enabled        :boolean          default(TRUE), not null
+#  company_id     :uuid             not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
 # Indexes
 #
-#  index_thematics_on_identifier  (identifier) UNIQUE
+#  index_thematics_on_company_id  (company_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
 
   enum :role, { standard: 0, admin: 1, super_admin: 2 }, validate: true
 
+  belongs_to :company, counter_cache: true
+
   has_one_attached :avatar
 
   authenticates_with_sorcery!
@@ -42,9 +44,11 @@ end
 #  reset_password_email_sent_at        :datetime
 #  access_count_to_reset_password_page :integer          default(0)
 #  role                                :integer          default("standard"), not null
+#  company_id                          :uuid
 #
 # Indexes
 #
+#  index_users_on_company_id            (company_id)
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_remember_me_token     (remember_me_token)
 #  index_users_on_reset_password_token  (reset_password_token)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -16,6 +16,10 @@ class ApplicationPolicy < ActionPolicy::Base
 
   private
 
+  def from_company?
+    deny! unless record.company_id == user.company_id
+  end
+
   def allow_super_admins
     deny! unless user.super_admin?
   end

--- a/app/policies/chapters/cover_policy.rb
+++ b/app/policies/chapters/cover_policy.rb
@@ -1,6 +1,7 @@
 module Chapters
   class CoverPolicy < ApplicationPolicy
     pre_check :allow_admins
+    pre_check :from_company?
 
     def update?
       chapter.story.enabled? && !chapter.published?
@@ -10,6 +11,11 @@ module Chapters
 
     def chapter
       record
+    end
+
+    # Override `from_company?` to reference story as record
+    def from_company?
+      deny! unless record.story.company_id == user.company_id
     end
   end
 end

--- a/app/policies/character_policy.rb
+++ b/app/policies/character_policy.rb
@@ -1,5 +1,6 @@
 class CharacterPolicy < ApplicationPolicy
   pre_check :allow_admins
+  pre_check :from_company?, except: %i[index? new? create?]
 
   def index?
     true

--- a/app/policies/nostr_user_policy.rb
+++ b/app/policies/nostr_user_policy.rb
@@ -1,5 +1,6 @@
 class NostrUserPolicy < ApplicationPolicy
   pre_check :allow_super_admins
+  pre_check :from_company?, except: %i[index? new? create?]
 
   def index?
     true

--- a/app/policies/place_policy.rb
+++ b/app/policies/place_policy.rb
@@ -1,5 +1,6 @@
 class PlacePolicy < ApplicationPolicy
   pre_check :allow_admins
+  pre_check :from_company?, except: %i[index? new? create?]
 
   def index?
     true

--- a/app/policies/prompt_policy.rb
+++ b/app/policies/prompt_policy.rb
@@ -1,5 +1,6 @@
 class PromptPolicy < ApplicationPolicy
   pre_check :allow_admins
+  pre_check :from_company?, except: %i[index? new? create?]
 
   def index?
     true

--- a/app/policies/relay_policy.rb
+++ b/app/policies/relay_policy.rb
@@ -1,5 +1,6 @@
 class RelayPolicy < ApplicationPolicy
   pre_check :allow_super_admins
+  pre_check :from_company?, except: %i[index? new? create?]
 
   def index?
     true

--- a/app/policies/setting_policy.rb
+++ b/app/policies/setting_policy.rb
@@ -1,5 +1,6 @@
 class SettingPolicy < ApplicationPolicy
   pre_check :allow_super_admins
+  pre_check :from_company?
 
   def edit?
     update?

--- a/app/policies/stories/chapter_policy.rb
+++ b/app/policies/stories/chapter_policy.rb
@@ -3,6 +3,7 @@ module Stories
     authorize :story
 
     pre_check :allow_admins
+    pre_check :from_company?, except: :create?
     pre_check :story_enabled?, except: :show?
 
     def create?
@@ -33,6 +34,11 @@ module Stories
 
     def story_enabled?
       deny! if !story.enabled? || story.ended?
+    end
+
+    # Override `from_company?` to reference story as record
+    def from_company?
+      deny! unless story.company_id == user.company_id
     end
   end
 end

--- a/app/policies/stories/cover_policy.rb
+++ b/app/policies/stories/cover_policy.rb
@@ -1,6 +1,7 @@
 module Stories
   class CoverPolicy < ApplicationPolicy
     pre_check :allow_admins
+    pre_check :from_company?
 
     def update?
       story.enabled? && !story.current? && !story.ended?

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -1,5 +1,6 @@
 class StoryPolicy < ApplicationPolicy
   pre_check :allow_admins
+  pre_check :from_company?, except: %i[new? create?]
 
   def new?
     true

--- a/app/policies/thematic_policy.rb
+++ b/app/policies/thematic_policy.rb
@@ -1,5 +1,6 @@
 class ThematicPolicy < ApplicationPolicy
   pre_check :allow_admins
+  pre_check :from_company?, except: %i[index? new? create?]
 
   def index?
     true

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -17,9 +17,11 @@ nav class="bg-white border-gray-200 dark:bg-gray-900"
       <!-- Dropdown menu -->
       div class="z-50 hidden my-4 text-base list-none bg-white divide-y divide-gray-100 rounded-lg shadow dark:bg-gray-700 dark:divide-gray-600" id="user-dropdown"
         .px-4.py-3
-          span.block.text-sm.text-gray-900.dark:text-white= current_user.email
+          span.block.text-sm.text-center.text-gray-600.truncate.dark:text-gray-300.uppercase.border-b.mb-2
+            = company.name
+          span.block.text-sm.text-center.text-gray-900.dark:text-white= current_user.email
           span.block.text-sm.text-center.text-gray-500.truncate.dark:text-gray-400
-            = current_user.role
+            | (#{current_user.role})
 
         ul.py-2 aria-labelledby="user-menu-button"
           li
@@ -111,7 +113,7 @@ nav class="bg-white border-gray-200 dark:bg-gray-900"
                             class: "menu-link #{'menu-link--active' if controller_path == 'prompts'}" do
                     | Les prompts
 
-        - if allowed_to?(:update?, Setting)
+        - if allowed_to?(:update?, company.setting)
           li
             = link_to edit_settings_path,
                       class: "#{link_class} #{'text-white bg-secondary-color' if params[:controller] == 'settings'}" do

--- a/app/views/layouts/session.html.slim
+++ b/app/views/layouts/session.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html class=options.theme
+html class="dark"
   head
     = seo_meta_tags
     = csrf_meta_tags

--- a/app/views/nostr_users/_form.html.slim
+++ b/app/views/nostr_users/_form.html.slim
@@ -49,7 +49,7 @@
         = image_tag f.object.banner_url, class: 'mx-auto mt-3 w-96'
 
   = f.association :relays,
-                  collection: Relay.enabled,
+                  collection: company.relays.enabled,
                   input_html: { \
                     data: { controller: 'slim-select' }, \
                     class: 'w-full' \

--- a/app/views/prompts/index.html.slim
+++ b/app/views/prompts/index.html.slim
@@ -1,10 +1,14 @@
 header.flex.flex-col.lg:flex-row.items-center.justify-between.mb-6.gap-3
-  .flex.items-center.gap-3
-    h1.text-3xl Les prompts
+  h1.text-3xl Les prompts
+  .flex.items-center.gap-1
     - if params[:archived].to_bool
       = link_to 'Disponibles', prompts_path, class: 'bg-black text-white p-1 text-sm'
     - else
       = link_to 'Archivés', prompts_path(archived: true), class: 'bg-black text-white p-1 text-sm'
+    - if allowed_to?(:create?, Prompt)
+      = link_to 'Ajouter prompt média +', new_prompt_path(type: Base64.encode64('MediaPrompt')), class: 'add-link !text-xs'
+      = link_to 'Ajouter prompt narrateur +', new_prompt_path(type: Base64.encode64('NarratorPrompt')), class: 'add-link !text-xs'
+      = link_to 'Ajouter prompt atmosphère +', new_prompt_path(type: Base64.encode64('AtmospherePrompt')), class: 'add-link !text-xs'
 
 details.panel-info.mb-5
   summary Explications à lire
@@ -20,10 +24,6 @@ details.panel-info.mb-5
         - if index.zero?
           header.flex.items-center.gap-3.mb-3
             p.text-center.font-bold.text-lg.dark:text-white= prompt.model_name.human.capitalize
-
-            - if allowed_to?(:create?, Prompt)
-              = link_to 'Ajouter +', new_prompt_path(type: Base64.encode64(prompt.model_name.to_s)), class: 'add-link !text-xs'
-
 
       div data-controller="sortable" data-sortable-ghost-class="bg-gray-200" data-sortable-filter-class="opacity-25" data-sortable-model-value=label.underscore
         = render collection: prompts, partial: 'prompts/prompt'

--- a/app/views/stories/_form.html.slim
+++ b/app/views/stories/_form.html.slim
@@ -15,7 +15,7 @@ details.panel-info.mb-5
 
   .flex.flex-col.lg:flex-row.gap-3.justify-between.w-full.mb-2
     = f.association :nostr_user,
-                    collection: story_nostr_users_select_options,
+                    collection: story_nostr_users_select_options(company),
                     include_blank: false,
                     label_html: { class: 'block italic mb-2' },
                     input_html: { \
@@ -55,7 +55,7 @@ details.panel-info.mb-5
 
   .flex.flex-col.lg:flex-row.items-center.gap-6.w-full.mb-6
     = f.association :thematic,
-                    collection: Thematic.enabled,
+                    collection: company.thematics.enabled,
                     include_blank: '[Aléatoire]',
                     label_html: { class: 'block italic mb-2' },
                     input_html: { \
@@ -67,7 +67,7 @@ details.panel-info.mb-5
                     wrapper_html: { class: 'text-center w-full' }
 
     = f.association :characters,
-                    collection: story_characters_select_options,
+                    collection: story_characters_select_options(company),
                     include_blank: false,
                     label_html: { class: 'block italic mb-2' },
                     input_html: { \
@@ -80,7 +80,7 @@ details.panel-info.mb-5
                     wrapper_html: { class: 'text-center w-full' }
 
     = f.association :places,
-                    collection: story_places_select_options,
+                    collection: story_places_select_options(company),
                     include_blank: false,
                     label_html: { class: 'block italic mb-2' },
                     input_html: { \
@@ -113,7 +113,7 @@ details.panel-info.mb-5
 
           .flex.flex-col.lg:flex-row.justify-center.gap-6
             = f.association :media_prompt,
-                            collection: MediaPrompt.enabled.available.by_position,
+                            collection: company.media_prompts.enabled.available.by_position,
                             include_blank: false,
                             input_html: { \
                               class: 'w-full', \
@@ -134,7 +134,7 @@ details.panel-info.mb-5
 
           .flex.flex-col.lg:flex-row.justify-center.gap-6
             = f.association :narrator_prompt,
-                            collection: NarratorPrompt.enabled.available.by_position,
+                            collection: company.narrator_prompts.enabled.available.by_position,
                             include_blank: false,
                             input_html: { \
                               class: 'w-full', \
@@ -145,7 +145,7 @@ details.panel-info.mb-5
                             wrapper_html: { class: 'text-center w-full' }
 
             = f.association :atmosphere_prompt,
-                            collection: AtmospherePrompt.enabled.available.by_position,
+                            collection: company.atmosphere_prompts.enabled.available.by_position,
                             include_blank: false,
                             input_html: { \
                               class: 'w-full', \

--- a/app/views/stories/_form_light.html.slim
+++ b/app/views/stories/_form_light.html.slim
@@ -41,7 +41,7 @@
               wrapper_html: { class: 'text-center w-full' }
 
     = f.association :nostr_user,
-                    collection: story_nostr_users_select_options,
+                    collection: story_nostr_users_select_options(company),
                     include_blank: false,
                     label_html: { class: 'block italic mb-2' },
                     input_html: { \

--- a/app/views/thematics/_form.html.slim
+++ b/app/views/thematics/_form.html.slim
@@ -1,8 +1,5 @@
 = simple_form_for(@thematic) do |f|
   .form-inputs
-    = f.input :identifier,
-              wrapper_html: { class: 'mb-5' }
-
     .flex.items-center.justify-between.gap-3
       = f.input :name_fr,
                 wrapper_html: { class: 'w-full mb-5' }

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -48,7 +48,6 @@ fr:
         lud16: Adresse LN
 
       thematic:
-        identifier: Identifiant
         name_fr: Nom en français
         name_en: Nom en anglais
         description_fr: Description en français

--- a/db/migrate/20230714160121_create_companies.rb
+++ b/db/migrate/20230714160121_create_companies.rb
@@ -1,0 +1,10 @@
+class CreateCompanies < ActiveRecord::Migration[7.1]
+  def change
+    create_table :companies, id: :uuid do |t|
+      t.string :name, index: { unique: true }
+      t.integer :users_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230715084559_add_company_references_to_users.rb
+++ b/db/migrate/20230715084559_add_company_references_to_users.rb
@@ -1,0 +1,5 @@
+class AddCompanyReferencesToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :users, :company, type: :uuid
+  end
+end

--- a/db/migrate/20230715093246_create_stories.rb
+++ b/db/migrate/20230715093246_create_stories.rb
@@ -5,6 +5,7 @@ class CreateStories < ActiveRecord::Migration[7.0]
       t.integer :chapters_count, null: false, default: 0
       t.datetime :adventure_ended_at
       t.json :raw_response_body, null: false, default: {}
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20230722204304_create_nostr_users.rb
+++ b/db/migrate/20230722204304_create_nostr_users.rb
@@ -6,6 +6,7 @@ class CreateNostrUsers < ActiveRecord::Migration[7.0]
       t.string :private_key
       t.string :relay_url
       t.integer :language, null: false, default: 0
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20230726151034_create_thematics.rb
+++ b/db/migrate/20230726151034_create_thematics.rb
@@ -1,13 +1,13 @@
 class CreateThematics < ActiveRecord::Migration[7.0]
   def change
     create_table :thematics, id: :uuid do |t|
-      t.string :identifier, index: { unique: true }
       t.string :name_fr
       t.string :name_en
       t.text :description_fr
       t.text :description_en
       t.integer :stories_count, null: false, default: 0
       t.boolean :enabled, null: false, default: true
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20230809112056_create_relays.rb
+++ b/db/migrate/20230809112056_create_relays.rb
@@ -1,11 +1,14 @@
 class CreateRelays < ActiveRecord::Migration[7.0]
   def change
     create_table :relays, id: :uuid do |t|
-      t.string :url, index: { unique: true }
+      t.string :url
       t.text :description
       t.boolean :enabled, null: false, default: true
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
+
+      t.index %i[company_id url], unique: true
     end
   end
 end

--- a/db/migrate/20230814162338_create_settings.rb
+++ b/db/migrate/20230814162338_create_settings.rb
@@ -2,6 +2,7 @@ class CreateSettings < ActiveRecord::Migration[7.0]
   def change
     create_table :settings do |t|
       t.jsonb :chapter_options, null: false, default: {}
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20230913085828_create_characters.rb
+++ b/db/migrate/20230913085828_create_characters.rb
@@ -5,6 +5,7 @@ class CreateCharacters < ActiveRecord::Migration[7.0]
       t.string :last_name
       t.text :biography
       t.boolean :enabled, null: false, default: true
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
 

--- a/db/migrate/20230913153558_create_places.rb
+++ b/db/migrate/20230913153558_create_places.rb
@@ -4,6 +4,7 @@ class CreatePlaces < ActiveRecord::Migration[7.0]
       t.string :name
       t.text :description
       t.boolean :enabled, null: false, default: true
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20230914082159_create_prompts.rb
+++ b/db/migrate/20230914082159_create_prompts.rb
@@ -10,6 +10,7 @@ class CreatePrompts < ActiveRecord::Migration[7.0]
       t.boolean :enabled, null: false, default: true
       t.integer :position, null: false, default: 1
       t.datetime :archived_at
+      t.references :company, null: false, foreign_key: true, type: :uuid
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,8 +70,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.string "last_name"
     t.text "biography"
     t.boolean "enabled", default: true, null: false
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_characters_on_company_id"
     t.index ["first_name", "last_name"], name: "index_characters_on_first_name_and_last_name", unique: true
   end
 
@@ -83,9 +85,18 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.index ["story_id"], name: "index_characters_stories_on_story_id"
   end
 
+  create_table "companies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.integer "users_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_companies_on_name", unique: true
+  end
+
   create_table "nostr_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "private_key"
     t.string "language", limit: 2, default: "EN", null: false
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "stories_count", default: 0, null: false
@@ -98,6 +109,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.string "website"
     t.string "lud16"
     t.string "display_name"
+    t.index ["company_id"], name: "index_nostr_users_on_company_id"
     t.index ["private_key"], name: "index_nostr_users_on_private_key", unique: true
   end
 
@@ -111,8 +123,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.string "name"
     t.text "description"
     t.boolean "enabled", default: true, null: false
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_places_on_company_id"
   end
 
   create_table "places_stories", id: false, force: :cascade do |t|
@@ -132,24 +146,30 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.boolean "enabled", default: true, null: false
     t.integer "position", default: 1, null: false
     t.datetime "archived_at"
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_prompts_on_company_id"
   end
 
   create_table "relays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "url"
     t.text "description"
     t.boolean "enabled", default: true, null: false
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position", default: 1, null: false
-    t.index ["url"], name: "index_relays_on_url", unique: true
+    t.index ["company_id", "url"], name: "index_relays_on_company_id_and_url", unique: true
+    t.index ["company_id"], name: "index_relays_on_company_id"
   end
 
   create_table "settings", force: :cascade do |t|
     t.jsonb "chapter_options", default: {}, null: false
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_settings_on_company_id"
   end
 
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
@@ -250,6 +270,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.integer "chapters_count", default: 0, null: false
     t.datetime "adventure_ended_at"
     t.json "raw_response_body", default: {}, null: false
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "mode", default: 0, null: false
@@ -270,6 +291,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.uuid "atmosphere_prompt_id"
     t.index ["atmosphere_prompt_id"], name: "index_stories_on_atmosphere_prompt_id"
     t.index ["back_cover_nostr_identifier"], name: "index_stories_on_back_cover_nostr_identifier", unique: true
+    t.index ["company_id"], name: "index_stories_on_company_id"
     t.index ["media_prompt_id"], name: "index_stories_on_media_prompt_id"
     t.index ["narrator_prompt_id"], name: "index_stories_on_narrator_prompt_id"
     t.index ["nostr_identifier"], name: "index_stories_on_nostr_identifier", unique: true
@@ -279,16 +301,16 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
   end
 
   create_table "thematics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "identifier"
     t.string "name_fr"
     t.string "name_en"
     t.text "description_fr"
     t.text "description_en"
     t.integer "stories_count", default: 0, null: false
     t.boolean "enabled", default: true, null: false
+    t.uuid "company_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["identifier"], name: "index_thematics_on_identifier", unique: true
+    t.index ["company_id"], name: "index_thematics_on_company_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -303,7 +325,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.uuid "company_id"
     t.integer "role", default: 0, null: false
+    t.index ["company_id"], name: "index_users_on_company_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
@@ -312,14 +336,22 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_171950) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "chapters", "stories"
+  add_foreign_key "characters", "companies"
+  add_foreign_key "nostr_users", "companies"
+  add_foreign_key "places", "companies"
+  add_foreign_key "prompts", "companies"
+  add_foreign_key "relays", "companies"
+  add_foreign_key "settings", "companies"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "stories", "companies"
   add_foreign_key "stories", "nostr_users"
   add_foreign_key "stories", "prompts", column: "atmosphere_prompt_id"
   add_foreign_key "stories", "prompts", column: "media_prompt_id"
   add_foreign_key "stories", "prompts", column: "narrator_prompt_id"
   add_foreign_key "stories", "thematics"
+  add_foreign_key "thematics", "companies"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,27 @@
 require 'open-uri'
 
+puts 'Seeding companies...'
+
+logo = FFaker::Image.url(size: '300x300')
+
+company = Company.create!(
+  name: FFaker::Company.name,
+  logo: {
+    io: URI.parse(logo).open,
+    filename: 'logo.png'
+  }
+)
+
 puts 'Seeding settings...'
 
-Setting.create!
+company.create_setting!
 
 puts 'Seeding users...'
 
 %i[standard admin super_admin].each do |role|
   avatar = FFaker::Avatar.image(size: '300x300')
 
-  User.create!(
+  company.users.create!(
     email: "#{role}@test.test",
     password: 'password',
     password_confirmation: 'password',
@@ -23,7 +35,7 @@ end
 
 puts 'Seeding relays...'
 
-relay = Relay.create!(
+relay = company.relays.create!(
   url: 'ws://umbrel.local:4848',
   description: 'Self-hosted relay on Umbrel server'
 )
@@ -31,7 +43,7 @@ relay = Relay.create!(
 puts 'Seeding nostr users...'
 
 if ENV.fetch('NOSTR_USER_FR_PRIVATE_KEY', nil).present?
-  nostr_user = NostrUser.create!(
+  nostr_user = company.nostr_users.create!(
     private_key: ENV.fetch('NOSTR_USER_FR_PRIVATE_KEY'),
     language: :fr,
     relays: [relay],
@@ -39,7 +51,7 @@ if ENV.fetch('NOSTR_USER_FR_PRIVATE_KEY', nil).present?
   )
   NostrServices::ImportProfile.call(nostr_user)
 else
-  nostr_user = NostrUser.create!(
+  nostr_user = company.nostr_users.create!(
     display_name: FFaker::Internet.user_name,
     private_key: FFaker::Crypto.sha256,
     language: :fr,
@@ -52,7 +64,7 @@ else
 end
 
 if ENV.fetch('NOSTR_USER_EN_PRIVATE_KEY', nil).present?
-  nostr_user = NostrUser.create!(
+  nostr_user = company.nostr_users.create!(
     private_key: ENV.fetch('NOSTR_USER_EN_PRIVATE_KEY'),
     language: :en,
     relays: [relay],
@@ -60,7 +72,7 @@ if ENV.fetch('NOSTR_USER_EN_PRIVATE_KEY', nil).present?
   )
   NostrServices::ImportProfile.call(nostr_user)
 else
-  nostr_user = NostrUser.create!(
+  nostr_user = company.nostr_users.create!(
     display_name: FFaker::Internet.user_name,
     private_key: FFaker::Crypto.sha256,
     language: :en,
@@ -76,42 +88,36 @@ puts 'Seeding thematics...'
 
 thematics = [
   {
-    identifier: 'escape_game',
     name_en: 'Escape Game',
     name_fr: 'Escape Game',
     description_en: "You wake up in a dark, closed room. Your objective is to find a solution to leave the place where you are.",
     description_fr: "Tu te réveilles dans une pièce sombre et fermée. Ton objectif est de trouver une solution pour quitter l'endroit où tu es."
   },
   {
-    identifier: 'jungle',
     name_en: 'A walk into the jungle',
     name_fr: 'Bienvenue dans la Jungle',
     description_en: "The user wakes up on a beautiful jungle, he will explore this jungle.",
     description_fr: "L'utilisateur se réveille dans un jungle luxuriante, il va explorer cette jungle."
   },
   {
-    identifier: 'sea',
     name_en: 'Sea adventure',
     name_fr: 'Aventure maritime',
     description_en: 'A sea adventure with lots of twists and exploration, accross ocean.',
     description_fr: "Aventure remplie de rebondissement et pleine d'exploration, à traverse les mers."
   },
   {
-    identifier: 'city',
     name_en: 'In the city',
     name_fr: 'En ville',
     description_en: 'An adventure with lots of twists and exploration, accross the city.',
     description_fr: "Une aventure remplie de rebondissement et pleine d'exploration, à travers la ville."
   },
   {
-    identifier: 'space',
     name_en: 'Space odyssey',
     name_fr: "Odyssée de l'espace",
     description_en: 'A Space odyssey adventure with lots of twists and exploration, in space.',
     description_fr: "Aventure Odyssée dans l'espace remplie de rebondissement et pleine d'exploration, à traverse l'univers."
   },
   {
-    identifier: 'garden',
     name_en: 'Accross gardens',
     name_fr: 'A travers les jardins',
     description_en: 'A walk accross gardens full of beautiful plants and flowers.',
@@ -119,7 +125,7 @@ thematics = [
   }
 ]
 
-Thematic.insert_all(thematics)
+company.thematics.insert_all(thematics)
 
 puts 'Seeding characters...'
 
@@ -162,7 +168,7 @@ characters = [
 ]
 
 characters.each do |character|
-  Character.create!(character)
+  company.characters.create!(character)
 end
 
 
@@ -252,7 +258,7 @@ places = [
 ]
 
 places.each do |place|
-  Place.create!(place)
+  company.places.create!(place)
 end
 
 puts 'Seeding prompts...'
@@ -378,9 +384,9 @@ atmosphere_prompts = [
   }
 ]
 
-MediaPrompt.insert_all(media_prompts)
-NarratorPrompt.insert_all(narrator_prompts)
-AtmospherePrompt.insert_all(atmosphere_prompts)
+company.media_prompts.insert_all(media_prompts)
+company.narrator_prompts.insert_all(narrator_prompts)
+company.atmosphere_prompts.insert_all(atmosphere_prompts)
 
 [MediaPrompt, NarratorPrompt, AtmospherePrompt].each do |model|
   model.order(:updated_at).each.with_index(1) do |prompt, index|

--- a/spec/factories/characters.rb
+++ b/spec/factories/characters.rb
@@ -3,5 +3,7 @@ FactoryBot.define do
     first_name { FFaker::Name.name }
     last_name { FFaker::Name.last_name }
     biography { FFaker::Lorem.paragraph }
+
+    company
   end
 end

--- a/spec/factories/company.rb
+++ b/spec/factories/company.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :company do
+    name { FFaker::Company.name }
+
+    after :create do |company|
+      create :setting, company: company
+    end
+  end
+end

--- a/spec/factories/nostr_users.rb
+++ b/spec/factories/nostr_users.rb
@@ -2,8 +2,12 @@ FactoryBot.define do
   factory :nostr_user do
     display_name { FFaker::Name.name }
     language { I18nData.languages.keys.sample }
-    sequence(:private_key) { FFaker::Crypto.sha256 }
+    private_key { FFaker::Crypto.sha256 }
 
-    relays { create_list :relay, 3 }
+    company
+
+    before :create do |nostr_user|
+      nostr_user.relays << create_list(:relay, 3, company: nostr_user.company)
+    end
   end
 end

--- a/spec/factories/places.rb
+++ b/spec/factories/places.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :place do
     name { FFaker::Lorem.sentence }
     description { FFaker::Lorem.paragraph }
+
+    company
   end
 end

--- a/spec/factories/prompts.rb
+++ b/spec/factories/prompts.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
 
     type { 'Prompt' }
 
+    company
+
     trait :archived do
       archived_at { 1.week.ago }
     end

--- a/spec/factories/relays.rb
+++ b/spec/factories/relays.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :relay do
     sequence(:url) { |n| "wss://relay#{n}.test" }
+
+    company
   end
 end

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -1,3 +1,5 @@
 FactoryBot.define do
-  factory :setting
+  factory :setting do
+    company
+  end
 end

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -3,12 +3,16 @@ FactoryBot.define do
     title { FFaker::Lorem.sentence }
     summary { FFaker::Lorem.sentence }
 
-    thematic
-    nostr_user
+    company
 
-    media_prompt
-    narrator_prompt
-    atmosphere_prompt
+    before :create do |story|
+      story.thematic = create :thematic, company: story.company
+      story.nostr_user = create :nostr_user, company: story.company
+
+      story.media_prompt = create :media_prompt, company: story.company
+      story.narrator_prompt = create :narrator_prompt, company: story.company
+      story.atmosphere_prompt = create :atmosphere_prompt, company: story.company
+    end
 
     trait :enabled do
       enabled { true }

--- a/spec/factories/thematics.rb
+++ b/spec/factories/thematics.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     name_en { FFaker::Lorem.sentence }
     description_fr { FFaker::Lorem.paragraph }
     description_en { FFaker::Lorem.paragraph }
-    identifier { FFaker::Lorem.word }
+
+    company
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
 
     password { 'password' }
     password_confirmation { password }
+
+    company
   end
 end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Character do
+  subject { build :character }
+
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_uniqueness_of(:last_name).scoped_to(:first_name) }
   it { is_expected.to validate_presence_of(:biography) }

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Company do
+  describe '[validations rules]' do
+    subject { build_stubbed :company }
+
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/nostr_user_spec.rb
+++ b/spec/models/nostr_user_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe NostrUser do
 
   describe '#mode' do
     subject(:nostr_user) do
-      described_class.new(mode: mode, display_name: 'John Doe')
+      described_class.new(mode: mode, display_name: 'John Doe', company: company)
     end
+
+    let(:company) { create :company }
 
     before do
       relay = build_stubbed :relay

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Place do
+  subject { build :place, company: shared_company }
+
+  include_context 'shared company'
+
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:description) }
 end

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Relay do
+  subject { build :relay }
+
   it { is_expected.to validate_presence_of(:url) }
-  it { is_expected.to validate_uniqueness_of(:url).case_insensitive }
+  it { is_expected.to validate_uniqueness_of(:url).scoped_to(:company_id).case_insensitive }
 
   describe '#title' do
     subject { relay.title }

--- a/spec/models/thematic_spec.rb
+++ b/spec/models/thematic_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Thematic do
+  subject { build :thematic }
+
   it { is_expected.to validate_presence_of(:name_fr) }
   it { is_expected.to validate_presence_of(:name_en) }
   it { is_expected.to validate_presence_of(:description_fr) }
   it { is_expected.to validate_presence_of(:description_en) }
-  it { is_expected.to validate_presence_of(:identifier) }
-  it { is_expected.to validate_uniqueness_of(:identifier).case_insensitive }
 end

--- a/spec/policies/chapters/cover_policy_spec.rb
+++ b/spec/policies/chapters/cover_policy_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Chapters::CoverPolicy do
-  let(:user) { build_stubbed :user, role }
+  let(:user) { create :user, role }
 
-  let(:story) { build_stubbed :story }
-  let(:record) { build_stubbed :chapter, story: story }
+  let(:story) { create :story, company: user.company }
+  let(:record) { create :chapter, story: story }
 
   let(:context) { { user: user } }
 
@@ -14,17 +14,42 @@ RSpec.describe Chapters::CoverPolicy do
         let(:role) { user_role }
 
         failed 'when chapter is already published' do
-          let(:record) { build_stubbed :chapter, :published }
+          let(:record) { create :chapter, :published, story: story }
         end
 
         failed 'when story is disabled' do
-          let(:story) { build_stubbed :story, :disabled }
+          let(:story) { create :story, :disabled, company: user.company }
         end
       end
     end
 
     failed 'when user is standard' do
       let(:role) { :standard }
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:story) { create :story, company: another_company }
+
+    describe_rule :update? do
+      %i[admin super_admin].each do |user_role|
+        failed "when user is #{user_role}" do
+          let(:role) { user_role }
+
+          failed 'when chapter is already published' do
+            let(:record) { create :chapter, :published, story: story }
+          end
+
+          failed 'when story is disabled' do
+            let(:story) { create :story, :disabled, company: another_company }
+          end
+        end
+      end
+
+      failed 'when user is standard' do
+        let(:role) { :standard }
+      end
     end
   end
 end

--- a/spec/policies/character_policy_spec.rb
+++ b/spec/policies/character_policy_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe CharacterPolicy do
-  let(:user) { build_stubbed :user, role }
+  let(:user) { create :user, role }
 
-  let(:record) { create :character }
+  let(:record) { create :character, company: user.company }
   let(:context) { { user: user } }
 
   describe_rule :update? do
@@ -15,6 +15,23 @@ RSpec.describe CharacterPolicy do
 
     failed 'when user is standard' do
       let(:role) { :standard }
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :place, company: another_company }
+
+    describe_rule :update? do
+      %i[admin super_admin].each do |user_role|
+        failed "when user is #{user_role}" do
+          let(:role) { user_role }
+        end
+      end
+
+      failed 'when user is standard' do
+        let(:role) { :standard }
+      end
     end
   end
 end

--- a/spec/policies/nostr_user_policy_spec.rb
+++ b/spec/policies/nostr_user_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe NostrUserPolicy do
-  let(:user) { build_stubbed :user, role }
-  let(:record) { build_stubbed :nostr_user }
+  let(:user) { create :user, role }
+  let(:record) { create :nostr_user, company: user.company }
 
   let(:context) { { user: user } }
 
@@ -18,6 +18,27 @@ RSpec.describe NostrUserPolicy do
 
       failed 'when user is standard' do
         let(:role) { :standard }
+      end
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :place, company: another_company }
+
+    %i[edit update destroy].each do |action|
+      describe_rule "#{action}?" do
+        failed 'when user is super admin' do
+          let(:role) { :super_admin }
+        end
+
+        failed 'when user is admin' do
+          let(:role) { :admin }
+        end
+
+        failed 'when user is standard' do
+          let(:role) { :standard }
+        end
       end
     end
   end

--- a/spec/policies/place_policy_spec.rb
+++ b/spec/policies/place_policy_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe PlacePolicy do
-  let(:user) { build_stubbed :user, role }
+  let(:user) { create :user, role }
 
-  let(:record) { create :place }
+  let(:record) { create :place, company: user.company }
   let(:context) { { user: user } }
 
   describe_rule :update? do
@@ -15,6 +15,23 @@ RSpec.describe PlacePolicy do
 
     failed 'when user is standard' do
       let(:role) { :standard }
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :place, company: another_company }
+
+    describe_rule :update? do
+      %i[admin super_admin].each do |user_role|
+        failed "when user is #{user_role}" do
+          let(:role) { user_role }
+        end
+      end
+
+      failed 'when user is standard' do
+        let(:role) { :standard }
+      end
     end
   end
 end

--- a/spec/policies/prompt_policy_spec.rb
+++ b/spec/policies/prompt_policy_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe PromptPolicy do
-  let(:user) { build_stubbed :user, role }
-  let(:record) { build_stubbed :narrator_prompt, stories_count: stories_count }
+  let(:company) { create :company }
+  let(:user) { create :user, role, company: company }
+  let(:record) { create :narrator_prompt, stories_count: stories_count, company: user.company }
 
   let(:context) { { user: user } }
   let(:stories_count) { 0 }
@@ -30,7 +31,7 @@ RSpec.describe PromptPolicy do
 
         succeed 'when prompt is not tied to any story and not last one' do
           before do
-            create_list :narrator_prompt, 2 # other prompt of this type
+            create_list :narrator_prompt, 2, company: user.company # other prompt of this type
           end
         end
 
@@ -42,6 +43,49 @@ RSpec.describe PromptPolicy do
 
     failed 'when user is standard' do
       let(:role) { :standard }
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :narrator_prompt, company: another_company }
+
+    %i[edit? update? archive?].each do |action|
+      describe_rule action do
+        failed 'when user is super admin' do
+          let(:role) { :super_admin }
+        end
+
+        failed 'when user is admin' do
+          let(:role) { :admin }
+        end
+
+        failed 'when user is standard' do
+          let(:role) { :standard }
+        end
+      end
+    end
+
+    describe_rule :destroy? do
+      %i[admin super_admin].each do |user_role|
+        describe "when user is #{user_role}" do
+          let(:role) { :super_admin }
+
+          failed 'when prompt is not tied to any story and not last one' do
+            before do
+              create_list :narrator_prompt, 2, company: another_company # other prompt of this type
+            end
+          end
+
+          failed 'when prompt is tied to stories' do
+            let(:stories_count) { 1 }
+          end
+        end
+      end
+
+      failed 'when user is standard' do
+        let(:role) { :standard }
+      end
     end
   end
 end

--- a/spec/policies/relay_policy_spec.rb
+++ b/spec/policies/relay_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe RelayPolicy do
-  let(:user) { build_stubbed :user, role }
-  let(:record) { build_stubbed :relay }
+  let(:user) { create :user, role }
+  let(:record) { create :relay, company: user.company }
 
   let(:context) { { user: user } }
 
@@ -18,6 +18,27 @@ RSpec.describe RelayPolicy do
 
       failed 'when user is standard' do
         let(:role) { :standard }
+      end
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :relay, company: another_company }
+
+    %i[edit update destroy].each do |action|
+      describe_rule "#{action}?" do
+        failed 'when user is super admin' do
+          let(:role) { :super_admin }
+        end
+
+        failed 'when user is admin' do
+          let(:role) { :admin }
+        end
+
+        failed 'when user is standard' do
+          let(:role) { :standard }
+        end
       end
     end
   end

--- a/spec/policies/setting_policy_spec.rb
+++ b/spec/policies/setting_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SettingPolicy do
-  let(:user) { build_stubbed :user, role }
-  let(:record) { build_stubbed :setting }
+  let(:user) { create :user, role }
+  let(:record) { create :setting, company: user.company }
 
   let(:context) { { user: user } }
 
@@ -18,6 +18,27 @@ RSpec.describe SettingPolicy do
 
       failed 'when user is standard' do
         let(:role) { :standard }
+      end
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :setting, company: another_company }
+
+    %i[edit update].each do |action|
+      describe_rule "#{action}?" do
+        failed 'when user is super admin' do
+          let(:role) { :super_admin }
+        end
+
+        failed 'when user is admin' do
+          let(:role) { :admin }
+        end
+
+        failed 'when user is standard' do
+          let(:role) { :standard }
+        end
       end
     end
   end

--- a/spec/policies/stories/chapter_policy_spec.rb
+++ b/spec/policies/stories/chapter_policy_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Stories::ChapterPolicy do
-  let(:user) { build_stubbed :user, role }
+  let(:user) { create :user, role }
 
-  let(:story) { create :story }
+  let(:story) { create :story, company: user.company }
   let(:record) { create :chapter, story: story }
 
   let(:context) { { user: user, story: story } }
@@ -15,11 +15,11 @@ RSpec.describe Stories::ChapterPolicy do
           let(:role) { user_role }
 
           failed 'when story is disabled' do
-            let(:story) { create :story, :disabled }
+            let(:story) { create :story, :disabled, company: user.company }
           end
 
           failed 'when story is ended' do
-            let(:story) { create :story, :ended }
+            let(:story) { create :story, :ended, company: user.company }
           end
         end
       end
@@ -36,6 +36,43 @@ RSpec.describe Stories::ChapterPolicy do
 
       failed 'when chapter is already published' do
         let(:record) { create :chapter, :published, story: story }
+      end
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:story) { create :story, company: another_company }
+
+    %i[publish? publish_next? publish_all?].each do |action|
+      describe_rule action do
+        %i[admin super_admin].each do |user_role|
+          failed "when user is #{user_role}" do
+            let(:role) { user_role }
+
+            failed 'when story is disabled' do
+              let(:story) { create :story, :disabled, company: another_company }
+            end
+
+            failed 'when story is ended' do
+              let(:story) { create :story, :ended, company: another_company }
+            end
+          end
+        end
+
+        failed 'when user is standard' do
+          let(:role) { :standard }
+        end
+      end
+    end
+
+    %i[publish? publish_next?].each do |action|
+      describe_rule action do
+        let(:role) { :admin }
+
+        failed 'when chapter is already published' do
+          let(:record) { create :chapter, :published, story: story }
+        end
       end
     end
   end

--- a/spec/policies/stories/cover_policy_spec.rb
+++ b/spec/policies/stories/cover_policy_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Stories::CoverPolicy do
-  let(:user) { build_stubbed :user, role }
+  let(:user) { create :user, role }
 
-  let(:record) { create :story }
+  let(:record) { create :story, company: user.company }
   let(:context) { { user: user } }
 
   describe_rule :update? do
@@ -12,21 +12,50 @@ RSpec.describe Stories::CoverPolicy do
         let(:role) { user_role }
 
         failed 'when story is already published' do
-          let(:record) { create :story, :published }
+          let(:record) { create :story, :published, company: user.company }
         end
 
         failed 'when story is disabled' do
-          let(:record) { create :story, :disabled }
+          let(:record) { create :story, :disabled, company: user.company }
         end
 
         failed 'when story is ended' do
-          let(:record) { create :story, :ended }
+          let(:record) { create :story, :ended, company: user.company }
         end
       end
     end
 
     failed 'when user is standard' do
       let(:role) { :standard }
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :story, company: another_company }
+
+    describe_rule :update? do
+      %i[admin super_admin].each do |user_role|
+        failed "when user is #{user_role}" do
+          let(:role) { user_role }
+
+          failed 'when story is already published' do
+            let(:record) { create :story, :published, company: another_company }
+          end
+
+          failed 'when story is disabled' do
+            let(:record) { create :story, :disabled, company: another_company }
+          end
+
+          failed 'when story is ended' do
+            let(:record) { create :story, :ended, company: another_company }
+          end
+        end
+      end
+
+      failed 'when user is standard' do
+        let(:role) { :standard }
+      end
     end
   end
 end

--- a/spec/policies/story_policy_spec.rb
+++ b/spec/policies/story_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe StoryPolicy do
-  let(:user) { build_stubbed :user, role }
-  let(:record) { build_stubbed :story }
+  let(:user) { create :user, role }
+  let(:record) { create :story, company: user.company }
 
   let(:context) { { user: user } }
 
@@ -37,6 +37,45 @@ RSpec.describe StoryPolicy do
 
     failed 'when user is standard' do
       let(:role) { :standard }
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :story, company: another_company }
+
+    %i[show? destroy?].each do |action|
+      describe_rule action do
+        failed 'when user is super admin' do
+          let(:role) { :super_admin }
+        end
+
+        failed 'when user is admin' do
+          let(:role) { :admin }
+        end
+
+        failed 'when user is standard' do
+          let(:role) { :standard }
+        end
+      end
+    end
+
+    describe_rule :update? do
+      failed 'when user is super admin' do
+        let(:role) { :super_admin }
+
+        failed 'when adventure is ended' do
+          before { record.adventure_ended_at = 1.day.ago }
+        end
+      end
+
+      failed 'when user is admin' do
+        let(:role) { :admin }
+      end
+
+      failed 'when user is standard' do
+        let(:role) { :standard }
+      end
     end
   end
 end

--- a/spec/policies/thematic_policy_spec.rb
+++ b/spec/policies/thematic_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ThematicPolicy do
-  let(:user) { build_stubbed :user, role }
-  let(:record) { build_stubbed :thematic }
+  let(:user) { create :user, role }
+  let(:record) { create :thematic, company: user.company }
 
   let(:context) { { user: user } }
 
@@ -18,6 +18,27 @@ RSpec.describe ThematicPolicy do
 
       failed 'when user is standard' do
         let(:role) { :standard }
+      end
+    end
+  end
+
+  context 'when record is from another company' do
+    let(:another_company) { create :company }
+    let(:record) { create :thematic, company: another_company }
+
+    %i[index new create edit update destroy].each do |action|
+      describe_rule "#{action}?" do
+        failed 'when user is super admin' do
+          let(:role) { :super_admin }
+        end
+
+        failed 'when user is admin' do
+          let(:role) { :admin }
+        end
+
+        failed 'when user is standard' do
+          let(:role) { :standard }
+        end
       end
     end
   end

--- a/spec/requests/characters_controller_spec.rb
+++ b/spec/requests/characters_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CharactersController do
+  include_context 'shared company'
+
   describe 'GET /characters' do
     subject(:action) { get '/characters' }
 
@@ -18,7 +20,7 @@ RSpec.describe CharactersController do
 
       context 'with some record' do
         before do
-          create_list :character, 2
+          create_list :character, 2, company: shared_company
           action
         end
 
@@ -78,7 +80,7 @@ RSpec.describe CharactersController do
   describe 'GET /characters/:id/edit' do
     subject(:action) { get "/characters/#{character.id}/edit" }
 
-    let(:character) { create :character }
+    let(:character) { create :character, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -98,7 +100,7 @@ RSpec.describe CharactersController do
     end
 
     let(:params) { {} }
-    let(:character) { create :character }
+    let(:character) { create :character, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -129,7 +131,7 @@ RSpec.describe CharactersController do
   describe 'DELETE /characters/:id' do
     subject(:action) { delete "/characters/#{character.id}" }
 
-    let!(:character) { create :character }
+    let!(:character) { create :character, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'

--- a/spec/requests/homes_controller_spec.rb
+++ b/spec/requests/homes_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe HomesController do
+  include_context 'shared company'
+
   describe 'GET /' do
     subject(:action) { get '/' }
 

--- a/spec/requests/nostr_users/refresh_profiles_controller_spec.rb
+++ b/spec/requests/nostr_users/refresh_profiles_controller_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe NostrUsers::RefreshProfilesController do
+  include_context 'shared company'
+
   describe 'POST /nostr_users/::id/refresh_profiles' do
     subject(:action) { post "/nostr_users/#{nostr_user.id}/refresh_profiles" }
 
-    let(:nostr_user) { create :nostr_user }
+    let(:nostr_user) { create :nostr_user, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'

--- a/spec/requests/nostr_users_controller_spec.rb
+++ b/spec/requests/nostr_users_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe NostrUsersController do
+  include_context 'shared company'
+
   describe 'GET /nostr_users' do
     subject(:action) { get '/nostr_users' }
 
@@ -19,7 +21,7 @@ RSpec.describe NostrUsersController do
 
       context 'with some record' do
         before do
-          create_list :nostr_user, 2
+          create_list :nostr_user, 2, company: shared_company
           action
         end
 
@@ -48,7 +50,7 @@ RSpec.describe NostrUsersController do
     subject(:action) { post '/nostr_users', params: { nostr_user: params } }
 
     let(:params) { {} }
-    let!(:relay) { create :relay }
+    let!(:relay) { create :relay, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -90,7 +92,7 @@ RSpec.describe NostrUsersController do
   describe 'GET /nostr_users/:id/edit' do
     subject(:action) { get "/nostr_users/#{nostr_user.id}/edit" }
 
-    let(:nostr_user) { create :nostr_user }
+    let(:nostr_user) { create :nostr_user, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -111,7 +113,7 @@ RSpec.describe NostrUsersController do
     end
 
     let(:params) { {} }
-    let(:nostr_user) { create :nostr_user }
+    let(:nostr_user) { create :nostr_user, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -144,7 +146,9 @@ RSpec.describe NostrUsersController do
       end
 
       describe 'language cannot be modified' do
-        let(:nostr_user) { create :nostr_user, language: 'FR' }
+        let(:nostr_user) do
+          create :nostr_user, language: 'FR', company: shared_company
+        end
         let(:params) { { language: 'ES' } }
 
         before { action }
@@ -157,7 +161,7 @@ RSpec.describe NostrUsersController do
   describe 'DELETE /nostr_users/:id' do
     subject(:action) { delete "/nostr_users/#{nostr_user.id}" }
 
-    let!(:nostr_user) { create :nostr_user }
+    let!(:nostr_user) { create :nostr_user, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'

--- a/spec/requests/places_controller_spec.rb
+++ b/spec/requests/places_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PlacesController do
+  include_context 'shared company'
+
   describe 'GET /places' do
     subject(:action) { get '/places' }
 
@@ -18,7 +20,7 @@ RSpec.describe PlacesController do
 
       context 'with some record' do
         before do
-          create_list :place, 2
+          create_list :place, 2, company: shared_company
           action
         end
 
@@ -78,7 +80,7 @@ RSpec.describe PlacesController do
   describe 'GET /places/:id/edit' do
     subject(:action) { get "/places/#{place.id}/edit" }
 
-    let(:place) { create :place }
+    let(:place) { create :place, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -98,7 +100,7 @@ RSpec.describe PlacesController do
     end
 
     let(:params) { {} }
-    let(:place) { create :place }
+    let(:place) { create :place, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -115,7 +117,7 @@ RSpec.describe PlacesController do
       end
 
       context 'when params are valid' do
-        let(:params) { { identifier: 'Foobar' } }
+        let(:params) { { name_fr: 'Foobar' } }
 
         include_examples 'a redirect response with success message' do
           let(:message) { 'Le lieu a bien été modifié' }
@@ -129,7 +131,7 @@ RSpec.describe PlacesController do
   describe 'DELETE /places/:id' do
     subject(:action) { delete "/places/#{place.id}" }
 
-    let!(:place) { create :place }
+    let!(:place) { create :place, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'

--- a/spec/requests/prompts_controller_spec.rb
+++ b/spec/requests/prompts_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PromptsController do
+  include_context 'shared company'
+
   describe 'GET /prompts' do
     subject(:action) { get '/prompts', params: params }
 
@@ -20,7 +22,7 @@ RSpec.describe PromptsController do
 
       context 'with some record' do
         before do
-          create_list :narrator_prompt, 2
+          create_list :narrator_prompt, 2, company: shared_company
           action
         end
 
@@ -31,8 +33,8 @@ RSpec.describe PromptsController do
         let(:params) { { archived: true } }
 
         before do
-          create :narrator_prompt
-          create :narrator_prompt, :archived
+          create :narrator_prompt, company: shared_company
+          create :narrator_prompt, :archived, company: shared_company
 
           action
         end
@@ -137,7 +139,7 @@ RSpec.describe PromptsController do
   describe 'GET /prompts/:id/edit' do
     subject(:action) { get "/prompts/#{prompt.id}/edit" }
 
-    let(:prompt) { create :narrator_prompt }
+    let(:prompt) { create :narrator_prompt, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -158,7 +160,7 @@ RSpec.describe PromptsController do
 
     let(:params) { {} }
     let(:prompt_kind) { :narrator_prompt }
-    let(:prompt) { create :narrator_prompt }
+    let(:prompt) { create :narrator_prompt, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -169,7 +171,7 @@ RSpec.describe PromptsController do
       %i[media_prompt narrator_prompt atmosphere_prompt].each do |kind|
         describe "with #{kind} prompt type" do
           let(:prompt_kind) { kind }
-          let(:prompt) { create kind }
+          let(:prompt) { create kind, company: shared_company }
 
           context 'when params are invalid' do
             let(:params) { { title: nil } }
@@ -196,7 +198,7 @@ RSpec.describe PromptsController do
   describe 'DELETE /prompts/:id' do
     subject(:action) { delete "/prompts/#{prompt.id}" }
 
-    let!(:prompt) { create :narrator_prompt }
+    let!(:prompt) { create :narrator_prompt, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -206,7 +208,7 @@ RSpec.describe PromptsController do
 
       context 'when there is more than one prompt' do
         before do
-          create :narrator_prompt
+          create :narrator_prompt, company: shared_company
         end
 
         it_behaves_like 'a redirect response with success message' do
@@ -231,7 +233,9 @@ RSpec.describe PromptsController do
   describe 'POST /prompts/:id/archive' do
     subject(:action) { post "/prompts/#{prompt.id}/archive" }
 
-    let!(:prompt) { create :narrator_prompt, archived_at: archived_at }
+    let!(:prompt) do
+      create :narrator_prompt, archived_at: archived_at, company: shared_company
+    end
     let(:archived_at) { nil }
 
     it_behaves_like 'a user not logged in'

--- a/spec/requests/public/stories_controller_spec.rb
+++ b/spec/requests/public/stories_controller_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Public::StoriesController do
+  include_context 'shared company'
+
   describe 'GET /p/s/:id.pdf' do
     subject(:action) { get "/p/s/#{story.id}.pdf" }
 
     context 'when story is viewable as PDF' do
-      let(:story) { create :story, :ended }
+      let(:story) { create :story, :ended, company: shared_company }
 
       before do
         create :chapter, :published, story: story
@@ -16,7 +18,7 @@ RSpec.describe Public::StoriesController do
     end
 
     context 'when story is not viewable as PDF' do
-      let(:story) { create :story }
+      let(:story) { create :story, company: shared_company }
 
       before { action }
 

--- a/spec/requests/relays_controller_spec.rb
+++ b/spec/requests/relays_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe RelaysController do
+  include_context 'shared company'
+
   describe 'GET /relays' do
     subject(:action) { get '/relays' }
 
@@ -19,7 +21,7 @@ RSpec.describe RelaysController do
 
       context 'with some record' do
         before do
-          create_list :relay, 2
+          create_list :relay, 2, company: shared_company
           action
         end
 
@@ -81,7 +83,7 @@ RSpec.describe RelaysController do
   describe 'GET /relays/:id/edit' do
     subject(:action) { get "/relays/#{relay.id}/edit" }
 
-    let(:relay) { create :relay }
+    let(:relay) { create :relay, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -102,7 +104,7 @@ RSpec.describe RelaysController do
     end
 
     let(:params) { {} }
-    let(:relay) { create :relay }
+    let(:relay) { create :relay, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -120,7 +122,7 @@ RSpec.describe RelaysController do
       end
 
       context 'when params are valid' do
-        let(:params) { { identifier: 'Foobar' } }
+        let(:params) { { name_fr: 'Foobar' } }
 
         include_examples 'a redirect response with success message' do
           let(:message) { 'Relay was successfully updated.' }
@@ -134,7 +136,7 @@ RSpec.describe RelaysController do
   describe 'DELETE /relays/:id' do
     subject(:action) { delete "/relays/#{relay.id}" }
 
-    let!(:relay) { create :relay }
+    let!(:relay) { create :relay, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'

--- a/spec/requests/settings_controller_spec.rb
+++ b/spec/requests/settings_controller_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe SettingsController do
-  before { create(:setting) unless Setting.exists? }
+  include_context 'shared company'
+
+  before { create(:setting, company: shared_company) unless Setting.exists? }
 
   describe 'GET /settings/edit' do
     subject(:action) { get '/settings/edit' }

--- a/spec/requests/stories/chapters/covers_controller_spec.rb
+++ b/spec/requests/stories/chapters/covers_controller_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Stories::Chapters::CoversController do
+  include_context 'shared company'
+
   describe 'PATCH /stories/:story_id/chapters/:chapter_id/covers' do
     subject(:action) { patch "/stories/#{story.id}/chapters/#{chapter.id}/covers" }
 
-    let(:story) { create :story }
+    let(:story) { create :story, company: shared_company }
     let(:chapter) { create :chapter, story: story, summary: 'my chapter summary' }
 
     before do

--- a/spec/requests/stories/chapters_controller_spec.rb
+++ b/spec/requests/stories/chapters_controller_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Stories::ChaptersController do
+  include_context 'shared company'
+
   describe 'POST /stories/:story_id/chapters' do
     subject(:action) { post "/stories/#{story.id}/chapters", params: params }
 
     let(:params) { {} }
-    let!(:story) { create :story }
+    let!(:story) { create :story, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -39,7 +41,7 @@ RSpec.describe Stories::ChaptersController do
   describe 'POST /stories/:story_id/chapters/publish_next' do
     subject(:action) { post "/stories/#{story.id}/chapters/publish_next" }
 
-    let(:story) { create :story }
+    let(:story) { create :story, company: shared_company }
     let!(:chapter) { create :chapter, story: story }
 
     it_behaves_like 'a user not logged in'
@@ -60,7 +62,7 @@ RSpec.describe Stories::ChaptersController do
   describe 'POST /stories/:story_id/chapters/publish_all' do
     subject(:action) { post "/stories/#{story.id}/chapters/publish_all" }
 
-    let(:story) { create :story }
+    let(:story) { create :story, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -82,7 +84,7 @@ RSpec.describe Stories::ChaptersController do
   describe 'POST /stories/:story_id/chapters/:id/publish' do
     subject(:action) { post "/stories/#{story.id}/chapters/#{chapter.id}/publish" }
 
-    let(:story) { create :story }
+    let(:story) { create :story, company: shared_company }
     let(:chapter) { create :chapter, story: story }
 
     it_behaves_like 'a user not logged in'

--- a/spec/requests/stories/covers_controller_spec.rb
+++ b/spec/requests/stories/covers_controller_spec.rb
@@ -1,10 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Stories::CoversController do
+  include_context 'shared company'
+
   describe 'PATCH /stories/:story_id/covers' do
     subject(:action) { patch "/stories/#{story.id}/covers" }
 
-    let(:story) { create :story, summary: 'my story summary' }
+    let(:story) do
+      create :story, summary: 'my story summary', company: shared_company
+    end
 
     before do
       allow(ReplicateServices::Picture).to receive(:call)

--- a/spec/requests/stories_controller_spec.rb
+++ b/spec/requests/stories_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe StoriesController do
+  include_context 'shared company'
+
   describe 'POST /stories' do
     subject(:action) { post '/stories', params: { story: params } }
 
@@ -12,11 +14,11 @@ RSpec.describe StoriesController do
     context 'when logged in with proper accreditation', as: :logged_in do
       let(:role) { :admin }
 
-      let(:thematic) { create :thematic }
-      let(:nostr_user) { create :nostr_user }
-      let(:media_prompt) { create :media_prompt }
-      let(:narrator_prompt) { create :narrator_prompt }
-      let(:atmosphere_prompt) { create :atmosphere_prompt }
+      let(:thematic) { create :thematic, company: shared_company }
+      let(:nostr_user) { create :nostr_user, company: shared_company }
+      let(:media_prompt) { create :media_prompt, company: shared_company }
+      let(:narrator_prompt) { create :narrator_prompt, company: shared_company }
+      let(:atmosphere_prompt) { create :atmosphere_prompt, company: shared_company }
       let(:mode) { :complete }
 
       let(:params) do
@@ -61,7 +63,7 @@ RSpec.describe StoriesController do
   describe 'PATCH /stories/:id' do
     subject(:action) { patch "/stories/#{story.id}" }
 
-    let(:story) { create :story }
+    let(:story) { create :story, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -70,7 +72,7 @@ RSpec.describe StoriesController do
       let(:role) { :admin }
 
       context 'when story is enabled' do
-        let(:story) { create :story, :enabled }
+        let(:story) { create :story, :enabled, company: shared_company }
 
         it { expect { action }.to change { story.reload.enabled }.from(true).to(false) }
 
@@ -81,7 +83,7 @@ RSpec.describe StoriesController do
       end
 
       context 'when story is disabled' do
-        let(:story) { create :story, :disabled }
+        let(:story) { create :story, :disabled, company: shared_company }
 
         it { expect { action }.to change { story.reload.enabled }.from(false).to(true) }
 
@@ -96,7 +98,7 @@ RSpec.describe StoriesController do
   describe 'DELETE /stories/:id' do
     subject(:action) { delete "/stories/#{story.id}" }
 
-    let!(:story) { create :story }
+    let!(:story) { create :story, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'

--- a/spec/requests/thematics_controller_spec.rb
+++ b/spec/requests/thematics_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ThematicsController do
+  include_context 'shared company'
+
   describe 'GET /thematics' do
     subject(:action) { get '/thematics' }
 
@@ -18,7 +20,7 @@ RSpec.describe ThematicsController do
 
       context 'with some record' do
         before do
-          create_list :thematic, 2
+          create_list :thematic, 2, company: shared_company
           action
         end
 
@@ -46,7 +48,7 @@ RSpec.describe ThematicsController do
     subject(:action) { post '/thematics', params: { thematic: params } }
 
     let(:params) { {} }
-    let(:relay) { create :relay }
+    let(:relay) { create :relay, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -56,7 +58,7 @@ RSpec.describe ThematicsController do
 
       context 'when params are invalid' do
         let(:params) do
-          attributes_for(:thematic).merge(identifier: nil)
+          attributes_for(:thematic).merge(name_fr: nil)
         end
 
         before { action }
@@ -78,7 +80,7 @@ RSpec.describe ThematicsController do
   describe 'GET /thematics/:id/edit' do
     subject(:action) { get "/thematics/#{thematic.id}/edit" }
 
-    let(:thematic) { create :thematic }
+    let(:thematic) { create :thematic, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -98,7 +100,7 @@ RSpec.describe ThematicsController do
     end
 
     let(:params) { {} }
-    let(:thematic) { create :thematic }
+    let(:thematic) { create :thematic, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'
@@ -107,7 +109,7 @@ RSpec.describe ThematicsController do
       let(:role) { :admin }
 
       context 'when params are invalid' do
-        let(:params) { { identifier: nil } }
+        let(:params) { { name_fr: nil } }
 
         before { action }
 
@@ -115,7 +117,7 @@ RSpec.describe ThematicsController do
       end
 
       context 'when params are valid' do
-        let(:params) { { identifier: 'Foobar' } }
+        let(:params) { { name_fr: 'Foobar' } }
 
         include_examples 'a redirect response with success message' do
           let(:message) { 'Thematic was successfully updated.' }
@@ -128,7 +130,7 @@ RSpec.describe ThematicsController do
   describe 'DELETE /thematics/:id' do
     subject(:action) { delete "/thematics/#{thematic.id}" }
 
-    let!(:thematic) { create :thematic }
+    let!(:thematic) { create :thematic, company: shared_company }
 
     it_behaves_like 'a user not logged in'
     it_behaves_like 'unauthorized request when logged in as standard'

--- a/spec/support/options.rb
+++ b/spec/support/options.rb
@@ -1,5 +1,0 @@
-RSpec.configure do |config|
-  config.before(:example, type: :request) do
-    create(:setting) unless Setting.exists?
-  end
-end

--- a/spec/support/shared_company.rb
+++ b/spec/support/shared_company.rb
@@ -1,0 +1,3 @@
+RSpec.shared_context 'shared company' do # rubocop:disable RSpec/ContextWording
+  let!(:shared_company) { create :company } # rubocop:disable RSpec/LetSetup
+end

--- a/spec/support/sorcery_test_helpers_rails.rb
+++ b/spec/support/sorcery_test_helpers_rails.rb
@@ -21,7 +21,9 @@ RSpec.configure do |config|
   config.include Sorcery::TestHelpers::Rails::Request, type: :request
 
   config.before(:example, as: :logged_in, type: :request) do
-    user = create :user, defined?(role) ? role : :admin
+    company = shared_company || create(:company)
+
+    user = create :user, defined?(role) ? role : :admin, company: company
     sign_in(user)
   end
 end


### PR DESCRIPTION
Resolves #53 

Scope models to `Company` resource to allow multiple independent companies with their own users, relays, nostr account, stories, ...

> [!Warning]
> This PR rewrites previous migrations and readapt them to handle `company` references.
> Drop and recreate your database to have an up-to-date structure.